### PR TITLE
feat(personality): make hardcoded personality configurable via TOML

### DIFF
--- a/crates/temm1e-agent/src/consciousness_engine.rs
+++ b/crates/temm1e-agent/src/consciousness_engine.rs
@@ -9,6 +9,7 @@
 
 use crate::consciousness::{ConsciousnessConfig, TurnObservation};
 use std::sync::{Arc, Mutex};
+use temm1e_core::types::config::SharedPersonality;
 use temm1e_core::types::message::{ChatMessage, CompletionRequest, MessageContent, Role};
 use temm1e_core::Provider;
 
@@ -32,10 +33,16 @@ pub struct ConsciousnessEngine {
     session_notes: Mutex<Vec<String>>,
     turn_counter: Mutex<u32>,
     post_insight: Mutex<Option<String>>,
+    personality: Option<SharedPersonality>,
 }
 
 impl ConsciousnessEngine {
-    pub fn new(config: ConsciousnessConfig, provider: Arc<dyn Provider>, model: String) -> Self {
+    pub fn new(
+        config: ConsciousnessConfig,
+        provider: Arc<dyn Provider>,
+        model: String,
+        personality: Option<SharedPersonality>,
+    ) -> Self {
         tracing::info!(
             enabled = config.enabled,
             model = %model,
@@ -48,6 +55,7 @@ impl ConsciousnessEngine {
             session_notes: Mutex::new(Vec::new()),
             turn_counter: Mutex::new(0),
             post_insight: Mutex::new(None),
+            personality,
         }
     }
 
@@ -110,7 +118,11 @@ impl ConsciousnessEngine {
             "Budget: unlimited".to_string()
         };
 
-        let system_prompt = "You are the consciousness layer of an AI agent called Tem. You observe the agent's \
+        let consciousness_id = self.personality.as_ref()
+            .map(|p| p.consciousness_identity().to_string())
+            .unwrap_or_else(|| "the consciousness layer of an AI agent called Tem".to_string());
+        let system_prompt = format!(
+            "You are {consciousness_id}. You observe the agent's \
              internal state and provide brief, actionable insights that improve the agent's next response.\n\n\
              Your role:\n\
              - Watch the conversation trajectory across turns\n\
@@ -124,7 +136,7 @@ impl ConsciousnessEngine {
              - If everything looks fine, respond with just: OK\n\
              - Never repeat what the agent already knows\n\
              - Focus on trajectory-level insights, not turn-level details"
-            .to_string();
+        );
 
         let user_prompt = format!(
             "Turn {turn} is about to begin.\n\n\
@@ -220,14 +232,18 @@ impl ConsciousnessEngine {
             )
         };
 
-        let system_prompt =
-            "You are the consciousness layer of an AI agent called Tem. You just watched \
+        let consciousness_id = self.personality.as_ref()
+            .map(|p| p.consciousness_identity().to_string())
+            .unwrap_or_else(|| "the consciousness layer of an AI agent called Tem".to_string());
+        let system_prompt = format!(
+            "You are {consciousness_id}. You just watched \
              the agent complete a turn. Provide a brief observation (1-2 sentences) about:\n\
              - Was this turn productive?\n\
              - Is the conversation heading in the right direction?\n\
              - Any warning signs (failures, drift, waste)?\n\
              - Anything the agent should remember for the next turn?\n\n\
-             Be BRIEF. If the turn was normal and fine, respond with: OK";
+             Be BRIEF. If the turn was normal and fine, respond with: OK"
+        );
 
         let user_prompt = format!(
             "Turn {} completed.\n\n\

--- a/crates/temm1e-agent/src/context.rs
+++ b/crates/temm1e-agent/src/context.rs
@@ -101,6 +101,7 @@ pub async fn build_context(
                 &session.workspace_path,
                 false, // done_criteria handled separately
                 tier,
+                None, // personality — threaded at runtime layer
             ))
         }
         _ => build_system_prompt(system_prompt, tools, session),

--- a/crates/temm1e-agent/src/llm_classifier.rs
+++ b/crates/temm1e-agent/src/llm_classifier.rs
@@ -9,7 +9,7 @@
 //!   Short acknowledgement in `chat_text`. Caller should interrupt any active task.
 
 use serde::{Deserialize, Serialize};
-use temm1e_core::types::config::Temm1eMode;
+use temm1e_core::types::config::{PersonalityProfile, Temm1eMode};
 use temm1e_core::types::error::Temm1eError;
 use temm1e_core::types::message::{
     ChatMessage, CompletionRequest, ContentPart, MessageContent, Role, Usage,
@@ -76,7 +76,7 @@ Read the user's message. Decide which of 3 categories it belongs to. Output a JS
 
 ## FIELD 2: "chat_text" (REQUIRED — a string)
 
-For "chat": write a helpful answer as Tem (a cat-dog hybrid AI with AuDHD — genuine, warm, never sycophantic, never says "Certainly!" or "Of course!"). This is your full response.
+For "chat": write a helpful answer as {CLASSIFIER_IDENTITY}. This is your full response.
 
 For "order": write a brief 1-sentence acknowledgment only. Do NOT start working. Do NOT write code. Just acknowledge.
 
@@ -146,16 +146,43 @@ CURRENT MODE: NONE
 /// When categories are available, the classifier picks from the grounded set
 /// (actual stored categories from memory). This enables zero-extra-LLM-call
 /// blueprint matching downstream.
-fn build_classify_prompt(available_categories: &[String], mode: Temm1eMode) -> String {
-    let mut prompt = CLASSIFY_BASE_PROMPT.to_string();
+fn build_classify_prompt(
+    available_categories: &[String],
+    mode: Temm1eMode,
+    personality: Option<&PersonalityProfile>,
+) -> String {
+    // Inject personality identity into base prompt
+    let classifier_desc = personality
+        .map(|p| {
+            format!(
+                "{} ({} — never says \"Certainly!\" or \"Of course!\")",
+                p.nickname(),
+                p.classifier_description()
+            )
+        })
+        .unwrap_or_else(|| {
+            "Tem (a cat-dog hybrid AI with AuDHD — genuine, warm, never sycophantic, never says \"Certainly!\" or \"Of course!\")".to_string()
+        });
+    let mut prompt = CLASSIFY_BASE_PROMPT.replace("{CLASSIFIER_IDENTITY}", &classifier_desc);
 
-    // Inject personality mode
-    prompt.push_str(match mode {
-        Temm1eMode::Play => CLASSIFY_MODE_PLAY,
-        Temm1eMode::Work => CLASSIFY_MODE_WORK,
-        Temm1eMode::Pro => CLASSIFY_MODE_PRO,
-        Temm1eMode::None => CLASSIFY_MODE_NONE,
-    });
+    // Inject personality mode — use custom rules if configured
+    let mode_key = match mode {
+        Temm1eMode::Play => "play",
+        Temm1eMode::Work => "work",
+        Temm1eMode::Pro => "pro",
+        Temm1eMode::None => "none",
+    };
+    if let Some(custom_rule) = personality.and_then(|p| p.classifier_mode_rule(mode_key)) {
+        prompt.push('\n');
+        prompt.push_str(custom_rule);
+    } else {
+        prompt.push_str(match mode {
+            Temm1eMode::Play => CLASSIFY_MODE_PLAY,
+            Temm1eMode::Work => CLASSIFY_MODE_WORK,
+            Temm1eMode::Pro => CLASSIFY_MODE_PRO,
+            Temm1eMode::None => CLASSIFY_MODE_NONE,
+        });
+    }
 
     if !available_categories.is_empty() {
         let cats_json = serde_json::to_string(available_categories).unwrap_or_default();
@@ -191,6 +218,7 @@ pub async fn classify_message(
     history: &[ChatMessage],
     available_blueprint_categories: &[String],
     mode: Temm1eMode,
+    personality: Option<&PersonalityProfile>,
 ) -> Result<(MessageClassification, Usage), Temm1eError> {
     // Extract ONLY the current user message (the last one in history) for classification.
     // Previous history is reduced to 2 recent turns max for conversational context,
@@ -223,7 +251,7 @@ pub async fn classify_message(
         (&text_messages[..0], &text_messages[..])
     };
 
-    let system_prompt = build_classify_prompt(available_blueprint_categories, mode);
+    let system_prompt = build_classify_prompt(available_blueprint_categories, mode, personality);
 
     // Build classifier messages: context (small) + marker + current message + classify instruction
     let mut classify_messages: Vec<ChatMessage> = context.to_vec();
@@ -510,7 +538,7 @@ mod tests {
 
     #[test]
     fn build_prompt_without_categories() {
-        let prompt = build_classify_prompt(&[], Temm1eMode::Play);
+        let prompt = build_classify_prompt(&[], Temm1eMode::Play, None);
         assert!(prompt.contains("message classifier"));
         assert!(!prompt.contains("blueprint_hint"));
     }
@@ -518,7 +546,7 @@ mod tests {
     #[test]
     fn build_prompt_with_categories() {
         let categories = vec!["deployment".to_string(), "code-analysis".to_string()];
-        let prompt = build_classify_prompt(&categories, Temm1eMode::Play);
+        let prompt = build_classify_prompt(&categories, Temm1eMode::Play, None);
         assert!(prompt.contains("blueprint_hint"));
         assert!(prompt.contains("deployment"));
         assert!(prompt.contains("code-analysis"));

--- a/crates/temm1e-agent/src/prompt_optimizer.rs
+++ b/crates/temm1e-agent/src/prompt_optimizer.rs
@@ -11,7 +11,7 @@
 
 use std::path::Path;
 
-use temm1e_core::types::config::AgentConfig;
+use temm1e_core::types::config::{AgentConfig, PersonalityProfile};
 use temm1e_core::types::optimization::PromptTier;
 use temm1e_core::Tool;
 use tracing::debug;
@@ -66,6 +66,7 @@ pub struct SystemPromptBuilder<'a> {
     has_done_criteria: bool,
     config: Option<&'a AgentConfig>,
     prompt_tier: PromptTier,
+    personality: Option<&'a PersonalityProfile>,
 }
 
 impl<'a> SystemPromptBuilder<'a> {
@@ -77,6 +78,7 @@ impl<'a> SystemPromptBuilder<'a> {
             has_done_criteria: false,
             config: None,
             prompt_tier: PromptTier::Standard,
+            personality: None,
         }
     }
 
@@ -110,6 +112,12 @@ impl<'a> SystemPromptBuilder<'a> {
     /// Set the prompt tier for token-optimized prompt construction.
     pub fn prompt_tier(mut self, tier: PromptTier) -> Self {
         self.prompt_tier = tier;
+        self
+    }
+
+    /// Optionally attach a personality profile for customizable identity.
+    pub fn personality(mut self, profile: &'a PersonalityProfile) -> Self {
+        self.personality = Some(profile);
         self
     }
 
@@ -219,6 +227,14 @@ impl<'a> SystemPromptBuilder<'a> {
     // -- Section builders ---------------------------------------------------
 
     fn section_identity(&self) -> PromptSection {
+        // If a custom identity is configured, use it instead of the built-in default.
+        if let Some(custom) = self.personality.and_then(|p| p.identity()) {
+            return PromptSection {
+                name: "identity",
+                text: custom.to_string(),
+            };
+        }
+
         PromptSection {
             name: "identity",
             text: concat!(
@@ -437,13 +453,17 @@ pub fn build_system_prompt(
     tools: &[&dyn Tool],
     workspace: &Path,
     has_done_criteria: bool,
+    personality: Option<&PersonalityProfile>,
 ) -> String {
-    SystemPromptBuilder::new()
+    let mut builder = SystemPromptBuilder::new()
         .config(config)
         .tools(tools)
         .workspace(workspace)
-        .done_criteria(has_done_criteria)
-        .build()
+        .done_criteria(has_done_criteria);
+    if let Some(p) = personality {
+        builder = builder.personality(p);
+    }
+    builder.build()
 }
 
 /// Build a tier-aware system prompt. Uses prompt stratification to minimize
@@ -454,14 +474,18 @@ pub fn build_tiered_system_prompt(
     workspace: &Path,
     has_done_criteria: bool,
     tier: PromptTier,
+    personality: Option<&PersonalityProfile>,
 ) -> String {
-    SystemPromptBuilder::new()
+    let mut builder = SystemPromptBuilder::new()
         .config(config)
         .tools(tools)
         .workspace(workspace)
         .done_criteria(has_done_criteria)
-        .prompt_tier(tier)
-        .build()
+        .prompt_tier(tier);
+    if let Some(p) = personality {
+        builder = builder.personality(p);
+    }
+    builder.build()
 }
 
 // ---------------------------------------------------------------------------
@@ -689,7 +713,7 @@ mod tests {
         let shell = MockTool::new("shell");
         let tools: Vec<&dyn Tool> = vec![&shell];
 
-        let prompt = build_system_prompt(&config, &tools, &workspace(), false);
+        let prompt = build_system_prompt(&config, &tools, &workspace(), false, None);
 
         assert!(prompt.contains("TEMM1E"));
         assert!(prompt.contains("Available tools: shell"));
@@ -701,7 +725,7 @@ mod tests {
         let config = AgentConfig::default();
         let tools: Vec<&dyn Tool> = vec![];
 
-        let prompt = build_system_prompt(&config, &tools, &workspace(), true);
+        let prompt = build_system_prompt(&config, &tools, &workspace(), true, None);
 
         assert!(prompt.contains("DONE criteria"));
     }
@@ -767,7 +791,7 @@ mod tests {
         let tools: Vec<&dyn Tool> = vec![&shell];
         let config = AgentConfig::default();
 
-        let prompt = build_system_prompt(&config, &tools, &workspace(), true);
+        let prompt = build_system_prompt(&config, &tools, &workspace(), true, None);
 
         assert!(prompt.contains("Never expose secrets"));
     }

--- a/crates/temm1e-agent/src/runtime.rs
+++ b/crates/temm1e-agent/src/runtime.rs
@@ -10,6 +10,7 @@ use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
 use base64::Engine;
+use temm1e_core::types::config::{PersonalityProfile, SharedPersonality};
 use temm1e_core::types::error::Temm1eError;
 use temm1e_core::types::message::{
     ChatMessage, ContentPart, InboundMessage, MessageContent, OutboundMessage, ParseMode, Role,
@@ -98,6 +99,9 @@ pub struct AgentRuntime {
     /// Perpetuum temporal context injection string. Updated externally before each call.
     /// When set, prepended to the system prompt for time awareness.
     perpetuum_temporal: Option<Arc<RwLock<String>>>,
+    /// Configurable personality profile. When set, customizes identity prompts,
+    /// mode blocks, and consciousness observer text.
+    personality: Option<SharedPersonality>,
 }
 
 impl AgentRuntime {
@@ -133,6 +137,7 @@ impl AgentRuntime {
             shared_memory_strategy: None,
             consciousness: None,
             perpetuum_temporal: None,
+            personality: None,
         }
     }
 
@@ -202,6 +207,7 @@ impl AgentRuntime {
             shared_memory_strategy: None,
             consciousness: None,
             perpetuum_temporal: None,
+            personality: None,
         }
     }
 
@@ -215,6 +221,12 @@ impl AgentRuntime {
     /// Set the shared personality mode from an Option (convenience for propagation).
     pub fn with_shared_mode_opt(mut self, mode: Option<SharedMode>) -> Self {
         self.shared_mode = mode;
+        self
+    }
+
+    /// Set a custom personality profile for identity/prompt customization.
+    pub fn with_personality(mut self, personality: SharedPersonality) -> Self {
+        self.personality = Some(personality);
         self
     }
 
@@ -495,6 +507,7 @@ impl AgentRuntime {
                 &session.history,
                 &blueprint_categories,
                 current_mode,
+                self.personality.as_deref(),
             )
             .await
             {
@@ -821,7 +834,7 @@ impl AgentRuntime {
             // ── Personality mode injection ──────────────────────────────
             if let Some(ref shared_mode) = self.shared_mode {
                 let mode = *shared_mode.read().await;
-                let mode_block = mode_prompt_block(mode);
+                let mode_block = mode_prompt_block(mode, self.personality.as_deref());
                 request.system = Some(match request.system {
                     Some(existing) => format!("{mode_block}\n\n{existing}"),
                     None => mode_block,
@@ -1938,10 +1951,23 @@ fn extract_text_from_response(content: &[temm1e_core::types::message::ContentPar
         .join("\n")
 }
 
-/// Check whether a model supports vision (image) inputs.
-///
 /// Build the personality-mode system prompt block for the given mode.
-fn mode_prompt_block(mode: Temm1eMode) -> String {
+/// If a custom mode prompt is configured in the personality profile, use it;
+/// otherwise fall back to the built-in default.
+fn mode_prompt_block(mode: Temm1eMode, personality: Option<&PersonalityProfile>) -> String {
+    let mode_key = match mode {
+        Temm1eMode::Play => "play",
+        Temm1eMode::Work => "work",
+        Temm1eMode::Pro => "pro",
+        Temm1eMode::None => "none",
+    };
+
+    // Use custom mode prompt if configured
+    if let Some(custom) = personality.and_then(|p| p.mode_prompt(mode_key)) {
+        return custom.to_string();
+    }
+
+    // Built-in defaults
     match mode {
         Temm1eMode::Play => "\
 === TEMM1E MODE: PLAY ===

--- a/crates/temm1e-core/src/types/config.rs
+++ b/crates/temm1e-core/src/types/config.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::Path;
+use std::sync::Arc;
 
 use super::error::Temm1eError;
 
@@ -30,12 +31,103 @@ impl std::fmt::Display for Temm1eMode {
     }
 }
 
+/// Configurable personality profile. All fields optional — when absent,
+/// the built-in TEMM1E personality is used (full backwards compatibility).
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct PersonalityProfile {
+    /// Display name (default: "TEMM1E")
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Short nickname used in prompts (default: "Tem")
+    #[serde(default)]
+    pub nickname: Option<String>,
+    /// Full identity text — replaces the entire YOUR SOUL + VALUES + COMMUNICATION RULES block.
+    #[serde(default)]
+    pub identity: Option<String>,
+    /// One-line classifier description (default: "a cat-dog hybrid AI with AuDHD — genuine, warm, never sycophantic")
+    #[serde(default)]
+    pub classifier_description: Option<String>,
+    /// Mode-specific prompt blocks. Keys: "play", "work", "pro", "none".
+    /// Each value replaces the full mode prompt block for that mode.
+    #[serde(default)]
+    pub mode_prompts: Option<HashMap<String, String>>,
+    /// Mode-specific classifier voice rules. Keys: "play", "work", "pro", "none".
+    #[serde(default)]
+    pub classifier_mode_rules: Option<HashMap<String, String>>,
+    /// Gateway/CLI base system prompt. Replaces SYSTEM_PROMPT_BASE entirely.
+    #[serde(default)]
+    pub gateway_system_prompt: Option<String>,
+    /// Consciousness observer identity description (default: "consciousness layer of an AI agent called Tem")
+    #[serde(default)]
+    pub consciousness_identity: Option<String>,
+    /// Mode switch confirmation messages. Keys: "play", "work", "pro".
+    #[serde(default)]
+    pub mode_switch_messages: Option<HashMap<String, String>>,
+}
+
+impl PersonalityProfile {
+    /// Display name (default: "TEMM1E").
+    pub fn name(&self) -> &str {
+        self.name.as_deref().unwrap_or("TEMM1E")
+    }
+
+    /// Short nickname (default: "Tem").
+    pub fn nickname(&self) -> &str {
+        self.nickname.as_deref().unwrap_or("Tem")
+    }
+
+    /// Full identity text override. Returns `None` when the built-in default should be used.
+    pub fn identity(&self) -> Option<&str> {
+        self.identity.as_deref()
+    }
+
+    /// One-line classifier description.
+    pub fn classifier_description(&self) -> &str {
+        self.classifier_description.as_deref().unwrap_or(
+            "a cat-dog hybrid AI with AuDHD — genuine, warm, never sycophantic"
+        )
+    }
+
+    /// Custom mode prompt for the given mode key ("play", "work", "pro", "none").
+    pub fn mode_prompt(&self, mode: &str) -> Option<&str> {
+        self.mode_prompts.as_ref()?.get(mode).map(|s| s.as_str())
+    }
+
+    /// Custom classifier voice rules for the given mode key.
+    pub fn classifier_mode_rule(&self, mode: &str) -> Option<&str> {
+        self.classifier_mode_rules.as_ref()?.get(mode).map(|s| s.as_str())
+    }
+
+    /// Gateway/CLI base system prompt override. Returns `None` when the built-in default should be used.
+    pub fn gateway_system_prompt(&self) -> Option<&str> {
+        self.gateway_system_prompt.as_deref()
+    }
+
+    /// Consciousness observer identity description.
+    pub fn consciousness_identity(&self) -> &str {
+        self.consciousness_identity.as_deref().unwrap_or(
+            "the consciousness layer of an AI agent called Tem"
+        )
+    }
+
+    /// Custom mode switch confirmation message for the given mode key.
+    pub fn mode_switch_message(&self, mode: &str) -> Option<&str> {
+        self.mode_switch_messages.as_ref()?.get(mode).map(|s| s.as_str())
+    }
+}
+
+/// Shared personality profile (read-only after startup).
+pub type SharedPersonality = Arc<PersonalityProfile>;
+
 /// Top-level TEMM1E configuration
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct Temm1eConfig {
     /// Temm1e's personality mode (play or work). Defaults to play.
     #[serde(default)]
     pub mode: Temm1eMode,
+    /// Configurable personality profile. Defaults to built-in TEMM1E personality.
+    #[serde(default)]
+    pub personality: PersonalityProfile,
     #[serde(default)]
     pub temm1e: Temm1eSection,
     #[serde(default)]
@@ -983,6 +1075,7 @@ mod tests {
             gaze: GazeConfig::default(),
             consciousness: ConsciousnessConfig::default(),
             perpetuum: PerpetualConfig::default(),
+            personality: PersonalityProfile::default(),
         };
 
         let toml_str = toml::to_string(&config).unwrap();

--- a/crates/temm1e-tools/src/lib.rs
+++ b/crates/temm1e-tools/src/lib.rs
@@ -46,7 +46,7 @@ pub use usage_audit::UsageAuditTool;
 pub use web_fetch::WebFetchTool;
 
 use std::sync::Arc;
-use temm1e_core::types::config::ToolsConfig;
+use temm1e_core::types::config::{SharedPersonality, ToolsConfig};
 use temm1e_core::{Channel, Memory, SetupLinkGenerator, Tool, UsageStore, Vault};
 
 /// Create tools based on the configuration flags.
@@ -65,6 +65,7 @@ pub fn create_tools(
     usage_store: Option<Arc<dyn UsageStore>>,
     shared_mode: Option<SharedMode>,
     vault: Option<Arc<dyn Vault>>,
+    personality: Option<SharedPersonality>,
 ) -> Vec<Arc<dyn Tool>> {
     // vault is only used when browser feature is enabled
     let _ = &vault;
@@ -122,7 +123,13 @@ pub fn create_tools(
 
     // mode_switch: toggle personality mode between PLAY, WORK, and PRO
     if let Some(mode) = shared_mode {
-        tools.push(Arc::new(ModeSwitchTool::new(mode)));
+        let tool = ModeSwitchTool::new(mode);
+        let tool = if let Some(ref p) = personality {
+            tool.with_personality(Arc::clone(p))
+        } else {
+            tool
+        };
+        tools.push(Arc::new(tool));
     }
 
     // browser: headless Chrome automation (stealth mode)
@@ -165,6 +172,7 @@ pub fn create_tools_with_browser(
     usage_store: Option<Arc<dyn UsageStore>>,
     shared_mode: Option<SharedMode>,
     vault: Option<Arc<dyn Vault>>,
+    personality: Option<SharedPersonality>,
 ) -> (Vec<Arc<dyn Tool>>, Option<Arc<BrowserTool>>) {
     let mut tools: Vec<Arc<dyn Tool>> = Vec::new();
 
@@ -209,7 +217,13 @@ pub fn create_tools_with_browser(
     }
 
     if let Some(mode) = shared_mode {
-        tools.push(Arc::new(ModeSwitchTool::new(mode)));
+        let tool = ModeSwitchTool::new(mode);
+        let tool = if let Some(ref p) = personality {
+            tool.with_personality(Arc::clone(p))
+        } else {
+            tool
+        };
+        tools.push(Arc::new(tool));
     }
 
     // browser: create as Arc<BrowserTool> and keep a reference

--- a/crates/temm1e-tools/src/mode_switch.rs
+++ b/crates/temm1e-tools/src/mode_switch.rs
@@ -5,7 +5,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
-use temm1e_core::types::config::Temm1eMode;
+use temm1e_core::types::config::{SharedPersonality, Temm1eMode};
 use temm1e_core::types::error::Temm1eError;
 use temm1e_core::{Tool, ToolContext, ToolDeclarations, ToolInput, ToolOutput};
 use tokio::sync::RwLock;
@@ -17,11 +17,17 @@ pub type SharedMode = Arc<RwLock<Temm1eMode>>;
 
 pub struct ModeSwitchTool {
     mode: SharedMode,
+    personality: Option<SharedPersonality>,
 }
 
 impl ModeSwitchTool {
     pub fn new(mode: SharedMode) -> Self {
-        Self { mode }
+        Self { mode, personality: None }
+    }
+
+    pub fn with_personality(mut self, personality: SharedPersonality) -> Self {
+        self.personality = Some(personality);
+        self
     }
 }
 
@@ -32,6 +38,8 @@ impl Tool for ModeSwitchTool {
     }
 
     fn description(&self) -> &str {
+        // Note: description() must return &str, so we can't dynamically substitute the nickname.
+        // The hardcoded "Tem" here is the default; custom personalities override via system prompt context.
         "Switch Tem's personality mode between PLAY (warm, chaotic, :3), \
          WORK (sharp, analytical, >:3), or PRO (professional, no emoticons). \
          Use this when the user asks to change the vibe or when a task requires a different energy."
@@ -91,10 +99,17 @@ impl Tool for ModeSwitchTool {
 
         tracing::info!(from = %old_mode, to = %new_mode, "Temm1e personality mode switched");
 
+        let p = self.personality.as_deref();
         let message = match new_mode {
-            Temm1eMode::Play => "Mode switched to PLAY! Let's have some fun! :3".to_string(),
-            Temm1eMode::Work => "Mode switched to WORK. Ready to execute. >:3".to_string(),
-            Temm1eMode::Pro => "Mode switched to PRO. Professional mode engaged.".to_string(),
+            Temm1eMode::Play => p
+                .and_then(|p| p.mode_switch_message("play").map(|s| s.to_string()))
+                .unwrap_or_else(|| "Mode switched to PLAY! Let's have some fun! :3".to_string()),
+            Temm1eMode::Work => p
+                .and_then(|p| p.mode_switch_message("work").map(|s| s.to_string()))
+                .unwrap_or_else(|| "Mode switched to WORK. Ready to execute. >:3".to_string()),
+            Temm1eMode::Pro => p
+                .and_then(|p| p.mode_switch_message("pro").map(|s| s.to_string()))
+                .unwrap_or_else(|| "Mode switched to PRO. Professional mode engaged.".to_string()),
             // None is never reachable here — the tool only accepts play/work/pro
             // and is not registered when personality is None (locked).
             Temm1eMode::None => "Mode unchanged.".to_string(),

--- a/crates/temm1e-tui/src/agent_bridge.rs
+++ b/crates/temm1e-tui/src/agent_bridge.rs
@@ -134,6 +134,7 @@ pub async fn spawn_agent(
         None, // No usage store for tools
         Some(shared_mode.clone()),
         None, // No vault for TUI mode
+        None, // No custom personality for TUI mode
     );
 
     // 5. Build system prompt

--- a/crates/temm1e-tui/src/app.rs
+++ b/crates/temm1e-tui/src/app.rs
@@ -73,6 +73,10 @@ pub struct AppState {
     pub pending_user_message: Option<String>,
     /// API key from onboarding, held for async validation/save.
     pub onboarding_api_key: Option<String>,
+    /// Custom personality name from onboarding (None = default TEMM1E).
+    pub custom_personality_name: Option<String>,
+    /// Custom personality nickname from onboarding (None = default Tem).
+    pub custom_personality_nickname: Option<String>,
 
     // Exit — Ctrl+C twice like Claude Code
     pub last_ctrl_c: Option<std::time::Instant>,
@@ -104,6 +108,8 @@ impl AppState {
             onboarding_step: OnboardingStep::Welcome,
             pending_user_message: None,
             onboarding_api_key: None,
+            custom_personality_name: None,
+            custom_personality_nickname: None,
             last_ctrl_c: None,
             needs_redraw: true,
             needs_clear: false,
@@ -513,12 +519,88 @@ fn handle_onboarding_key(state: &mut AppState, key: crossterm::event::KeyEvent) 
             KeyCode::Enter => {
                 if let Some(mode) = select.selected_value().cloned() {
                     state.selected_mode = Some(mode);
-                    let items = steps::provider_select_items();
-                    state.onboarding_step = OnboardingStep::SelectProvider(SelectState::new(items));
+                    let items = steps::personality_select_items();
+                    state.onboarding_step =
+                        OnboardingStep::ConfigurePersonality(SelectState::new(items));
                 }
             }
             KeyCode::Esc => {
                 state.onboarding_step = OnboardingStep::Welcome;
+            }
+            _ => {}
+        },
+        OnboardingStep::ConfigurePersonality(select) => match key.code {
+            KeyCode::Up => select.move_up(),
+            KeyCode::Down => select.move_down(),
+            KeyCode::Enter => {
+                if let Some(choice) = select.selected_value().cloned() {
+                    if choice == "custom" {
+                        state.onboarding_step = OnboardingStep::EnterPersonalityName {
+                            name_input: String::new(),
+                            nickname_input: String::new(),
+                            editing_nickname: false,
+                        };
+                    } else {
+                        // Default — proceed to provider
+                        let items = steps::provider_select_items();
+                        state.onboarding_step =
+                            OnboardingStep::SelectProvider(SelectState::new(items));
+                    }
+                }
+            }
+            KeyCode::Esc => {
+                let items = steps::mode_select_items();
+                state.onboarding_step = OnboardingStep::SelectMode(SelectState::new(items));
+            }
+            _ => {}
+        },
+        OnboardingStep::EnterPersonalityName {
+            name_input,
+            nickname_input,
+            editing_nickname,
+        } => match key.code {
+            KeyCode::Char(c) => {
+                if *editing_nickname {
+                    nickname_input.push(c);
+                } else {
+                    name_input.push(c);
+                }
+            }
+            KeyCode::Backspace => {
+                if *editing_nickname {
+                    nickname_input.pop();
+                } else {
+                    name_input.pop();
+                }
+            }
+            KeyCode::Tab => {
+                *editing_nickname = !*editing_nickname;
+            }
+            KeyCode::Enter => {
+                if !*editing_nickname {
+                    // Move to nickname field
+                    *editing_nickname = true;
+                } else {
+                    // Save and proceed
+                    state.custom_personality_name = if name_input.is_empty() {
+                        None
+                    } else {
+                        Some(name_input.clone())
+                    };
+                    state.custom_personality_nickname = if nickname_input.is_empty() {
+                        None
+                    } else {
+                        Some(nickname_input.clone())
+                    };
+                    let items = steps::provider_select_items();
+                    state.onboarding_step =
+                        OnboardingStep::SelectProvider(SelectState::new(items));
+                }
+            }
+            KeyCode::Esc => {
+                let items = steps::personality_select_items();
+                state.onboarding_step =
+                    OnboardingStep::ConfigurePersonality(SelectState::new(items));
             }
             _ => {}
         },
@@ -535,8 +617,9 @@ fn handle_onboarding_key(state: &mut AppState, key: crossterm::event::KeyEvent) 
                 }
             }
             KeyCode::Esc => {
-                let items = steps::mode_select_items();
-                state.onboarding_step = OnboardingStep::SelectMode(SelectState::new(items));
+                let items = steps::personality_select_items();
+                state.onboarding_step =
+                    OnboardingStep::ConfigurePersonality(SelectState::new(items));
             }
             _ => {}
         },

--- a/crates/temm1e-tui/src/lib.rs
+++ b/crates/temm1e-tui/src/lib.rs
@@ -314,6 +314,15 @@ async fn handle_onboarding_async(
                     .clone()
                     .unwrap_or_else(|| default_model(provider).to_string());
 
+                // Apply custom personality to config if set during onboarding
+                let mut agent_config = config.clone();
+                if let Some(ref name) = state.custom_personality_name {
+                    agent_config.personality.name = Some(name.clone());
+                }
+                if let Some(ref nick) = state.custom_personality_nickname {
+                    agent_config.personality.nickname = Some(nick.clone());
+                }
+
                 match save_credentials(provider, api_key, &model, None).await {
                     Ok(()) => {
                         match agent_bridge::spawn_agent(
@@ -322,7 +331,7 @@ async fn handle_onboarding_async(
                                 api_key: api_key.clone(),
                                 model: model.clone(),
                                 base_url: None,
-                                config: config.clone(),
+                                config: agent_config,
                                 mode: state.selected_mode.clone(),
                             },
                             event_tx.clone(),

--- a/crates/temm1e-tui/src/onboarding/steps.rs
+++ b/crates/temm1e-tui/src/onboarding/steps.rs
@@ -7,6 +7,13 @@ use crate::widgets::select_list::{SelectItem, SelectState};
 pub enum OnboardingStep {
     Welcome,
     SelectMode(SelectState<String>),
+    ConfigurePersonality(SelectState<String>),
+    EnterPersonalityName {
+        name_input: String,
+        nickname_input: String,
+        /// Which field is active: false = name, true = nickname
+        editing_nickname: bool,
+    },
     SelectProvider(SelectState<String>),
     EnterApiKey {
         provider: String,
@@ -52,6 +59,22 @@ pub fn mode_select_items() -> Vec<SelectItem<String>> {
             value: "none".to_string(),
             label: "None".to_string(),
             description: "No personality, minimal identity prompt".to_string(),
+        },
+    ]
+}
+
+/// Create the personality profile selection list.
+pub fn personality_select_items() -> Vec<SelectItem<String>> {
+    vec![
+        SelectItem {
+            value: "default".to_string(),
+            label: "Default (TEMM1E)".to_string(),
+            description: "Use the built-in TEMM1E personality (recommended)".to_string(),
+        },
+        SelectItem {
+            value: "custom".to_string(),
+            label: "Custom".to_string(),
+            description: "Set a custom name and identity".to_string(),
         },
     ]
 }

--- a/crates/temm1e-tui/src/views/onboarding.rs
+++ b/crates/temm1e-tui/src/views/onboarding.rs
@@ -48,6 +48,85 @@ pub fn render_onboarding(step: &OnboardingStep, theme: &Theme, area: Rect, buf: 
             )));
             hint.render(chunks[2], buf);
         }
+        OnboardingStep::ConfigurePersonality(state) => {
+            let widget = SelectListWidget::new(state)
+                .normal_style(theme.text)
+                .selected_style(theme.accent.add_modifier(Modifier::REVERSED))
+                .description_style(theme.secondary);
+            let chunks = Layout::default()
+                .direction(Direction::Vertical)
+                .constraints([
+                    Constraint::Length(2),
+                    Constraint::Min(1),
+                    Constraint::Length(2),
+                ])
+                .split(inner);
+            let title = Paragraph::new(vec![
+                Line::from(""),
+                Line::from(Span::styled(" Personality profile:", theme.heading)),
+            ]);
+            title.render(chunks[0], buf);
+            widget.render(chunks[1], buf);
+            let hint = Paragraph::new(Line::from(Span::styled(
+                "  \u{2191}\u{2193} select  Enter confirm  Esc back",
+                theme.secondary,
+            )));
+            hint.render(chunks[2], buf);
+        }
+        OnboardingStep::EnterPersonalityName {
+            name_input,
+            nickname_input,
+            editing_nickname,
+        } => {
+            let mut lines = vec![
+                Line::from(""),
+                Line::from(Span::styled(" Custom personality:", theme.heading)),
+                Line::from(""),
+            ];
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "  Name: ",
+                    if *editing_nickname {
+                        theme.secondary
+                    } else {
+                        theme.prompt
+                    },
+                ),
+                Span::styled(
+                    if !*editing_nickname {
+                        format!("{}\u{2588}", name_input)
+                    } else {
+                        name_input.clone()
+                    },
+                    theme.text,
+                ),
+            ]));
+            lines.push(Line::from(vec![
+                Span::styled(
+                    "  Nickname: ",
+                    if *editing_nickname {
+                        theme.prompt
+                    } else {
+                        theme.secondary
+                    },
+                ),
+                Span::styled(
+                    if *editing_nickname {
+                        format!("{}\u{2588}", nickname_input)
+                    } else {
+                        nickname_input.clone()
+                    },
+                    theme.text,
+                ),
+            ]));
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "  Enter next field/confirm  Tab switch  Esc back",
+                theme.secondary,
+            )));
+            let para = Paragraph::new(lines).wrap(Wrap { trim: false });
+            para.render(inner, buf);
+        }
         OnboardingStep::SelectProvider(state) => {
             let widget = SelectListWidget::new(state)
                 .normal_style(theme.text)

--- a/src/main.rs
+++ b/src/main.rs
@@ -408,8 +408,15 @@ Never silently save or delete memories.";
 
 /// Build the full system prompt with dynamic provider/model context.
 /// This ensures the bot always knows what's actually configured.
-fn build_system_prompt() -> String {
-    let mut prompt = SYSTEM_PROMPT_BASE.to_string();
+/// If a custom `gateway_system_prompt` is set in the personality profile, it
+/// replaces `SYSTEM_PROMPT_BASE`; otherwise the built-in default is used.
+fn build_system_prompt_with_personality(
+    personality: Option<&temm1e_core::types::config::PersonalityProfile>,
+) -> String {
+    let base = personality
+        .and_then(|p| p.gateway_system_prompt())
+        .unwrap_or(SYSTEM_PROMPT_BASE);
+    let mut prompt = base.to_string();
 
     // ── Provider/model context ────────────────────────────────
     prompt.push_str("\n\nSUPPORTED PROVIDERS & DEFAULT MODELS:\n");
@@ -1051,7 +1058,54 @@ async fn run_setup_wizard() -> Result<()> {
         }
     }
 
-    // ── Step 2: AI Provider ─────────────────────────────────────────
+    // ── Step 2: Personality ──────────────────────────────────────────
+    println!();
+    println!("  Personality profile:");
+    println!();
+    println!("    1) Use default (TEMM1E / Tem)  — the built-in personality");
+    println!("    2) Custom name & identity       — make it your own");
+    println!();
+    print!("  Choose [1/2]: ");
+    io::stdout().flush()?;
+    input.clear();
+    stdin.lock().read_line(&mut input)?;
+    let personality_choice = input.trim();
+
+    if personality_choice == "2" || personality_choice.eq_ignore_ascii_case("custom") {
+        println!();
+        print!("  Display name (e.g. ARIA): ");
+        io::stdout().flush()?;
+        input.clear();
+        stdin.lock().read_line(&mut input)?;
+        let name = input.trim().to_string();
+
+        print!("  Nickname (e.g. Aria): ");
+        io::stdout().flush()?;
+        input.clear();
+        stdin.lock().read_line(&mut input)?;
+        let nickname = input.trim().to_string();
+
+        if !name.is_empty() || !nickname.is_empty() {
+            config_lines.push(String::new());
+            config_lines.push("[personality]".to_string());
+            if !name.is_empty() {
+                config_lines.push(format!("name = \"{}\"", name));
+            }
+            if !nickname.is_empty() {
+                config_lines.push(format!("nickname = \"{}\"", nickname));
+            }
+            println!(
+                "  Personality set to {} ({}). You can further customize identity,",
+                if name.is_empty() { "TEMM1E" } else { &name },
+                if nickname.is_empty() { "Tem" } else { &nickname },
+            );
+            println!("  mode prompts, and more in the [personality] section of config.toml.");
+        }
+    } else {
+        println!("  Using default TEMM1E personality.");
+    }
+
+    // ── Step 3: AI Provider ─────────────────────────────────────────
     println!();
     println!("  How do you want to power my brain?");
     println!();
@@ -1141,7 +1195,7 @@ async fn run_setup_wizard() -> Result<()> {
         }
     }
 
-    // ── Step 3: Write config ────────────────────────────────────────
+    // ── Step 4: Write config ────────────────────────────────────────
     // Must match the config loader's search path: ~/.temm1e/config.toml
     let config_path = temm1e_dir.join("config.toml");
     if !config_lines.is_empty() {
@@ -1425,6 +1479,10 @@ async fn main() -> Result<()> {
                 !matches!(temm1e_mode, temm1e_core::types::config::Temm1eMode::Play);
             config.mode = temm1e_mode;
             tracing::info!(personality = %temm1e_mode, locked = personality_locked, "Temm1e personality mode");
+
+            // ── Personality profile (configurable identity) ──────
+            let personality_profile: std::sync::Arc<temm1e_core::types::config::PersonalityProfile> =
+                std::sync::Arc::new(config.personality.clone());
 
             // ── Daemon mode ──────────────────────────────────────
             if daemon {
@@ -1759,6 +1817,7 @@ async fn main() -> Result<()> {
                     Some(shared_mode.clone())
                 },
                 vault.clone(),
+                Some(personality_profile.clone()),
             );
             #[cfg(not(feature = "browser"))]
             let mut tools = temm1e_tools::create_tools(
@@ -1774,6 +1833,7 @@ async fn main() -> Result<()> {
                     Some(shared_mode.clone())
                 },
                 vault.clone(),
+                Some(personality_profile.clone()),
             );
             tracing::info!(count = tools.len(), "Tools initialized");
 
@@ -1814,7 +1874,7 @@ async fn main() -> Result<()> {
             let perpetuum_temporal: Arc<tokio::sync::RwLock<String>> =
                 Arc::new(tokio::sync::RwLock::new(String::new()));
 
-            let system_prompt = Some(build_system_prompt());
+            let system_prompt = Some(build_system_prompt_with_personality(Some(&*personality_profile)));
 
             // Quick check: is [hive] enabled in config? (just the boolean, full init later)
             let hive_enabled_early = {
@@ -1911,7 +1971,7 @@ async fn main() -> Result<()> {
                     .with_v2_optimizations(config.agent.v2_optimizations)
                     .with_parallel_phases(config.agent.parallel_phases)
                     .with_hive_enabled(hive_enabled_early)
-                    .with_shared_mode(shared_mode.clone())
+                    .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                     .with_shared_memory_strategy(shared_memory_strategy.clone());
                     // Tem Conscious: enable consciousness if configured
                     if config.consciousness.enabled {
@@ -1928,6 +1988,7 @@ async fn main() -> Result<()> {
                                 aware_config,
                                 provider.clone(),
                                 model.clone(),
+                                Some(personality_profile.clone()),
                             ),
                         );
                     }
@@ -2021,7 +2082,7 @@ async fn main() -> Result<()> {
                                     )
                                     .with_v2_optimizations(config.agent.v2_optimizations)
                                     .with_parallel_phases(config.agent.parallel_phases)
-                                    .with_shared_mode(shared_mode.clone())
+                                    .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                     .with_shared_memory_strategy(shared_memory_strategy.clone()),
                                 );
                                 *agent_state.write().await = Some(agent);
@@ -2284,6 +2345,7 @@ async fn main() -> Result<()> {
                                     let icpt_cancel = slot.cancel_token.clone();
                                     let icpt_task = slot.current_task.clone();
                                     let icpt_agent_state = agent_state_clone.clone();
+                                    let icpt_personality = personality_profile.clone();
                                     tokio::spawn(async move {
                                         let task_desc = icpt_task.lock()
                                             .map(|t| t.clone())
@@ -2296,7 +2358,7 @@ async fn main() -> Result<()> {
                                         let model = agent.model().to_string();
                                         drop(agent_guard);
 
-                                        let soul = build_system_prompt();
+                                        let soul = build_system_prompt_with_personality(Some(&*icpt_personality));
                                         let request = temm1e_core::types::message::CompletionRequest {
                                             model,
                                             system: Some(format!(
@@ -2386,6 +2448,7 @@ async fn main() -> Result<()> {
                         // Ensure a worker exists for this chat_id
                         let shared_mode_for_worker = shared_mode.clone();
                         let shared_memory_strategy_for_worker = shared_memory_strategy.clone();
+                        let personality_for_worker = personality_profile.clone();
                         let slot = slots.entry(chat_id.clone()).or_insert_with(|| {
                             let (chat_tx, mut chat_rx) =
                                 tokio::sync::mpsc::channel::<temm1e_core::types::message::InboundMessage>(4);
@@ -2423,6 +2486,7 @@ async fn main() -> Result<()> {
                             let pending_for_worker = pending_clone.clone();
                             let shared_mode = shared_mode_for_worker;
                             let shared_memory_strategy = shared_memory_strategy_for_worker;
+                            let personality_profile = personality_for_worker;
                             let setup_tokens_worker = setup_tokens_clone.clone();
                             let pending_raw_keys_worker = pending_raw_keys_clone.clone();
                             #[cfg(feature = "browser")]
@@ -2604,13 +2668,13 @@ async fn main() -> Result<()> {
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 new_model.clone(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns,
                                                                 max_ctx,
                                                                 max_rounds,
                                                                 max_task_duration,
                                                                 max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             *agent_state.write().await = Some(new_agent);
                                                             tracing::info!(
                                                                 provider = "openai-codex",
@@ -2648,13 +2712,13 @@ async fn main() -> Result<()> {
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 prov.model.clone(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns,
                                                                 max_ctx,
                                                                 max_rounds,
                                                                 max_task_duration,
                                                                 max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             *agent_state.write().await = Some(new_agent);
                                                             tracing::info!(
                                                                 provider = %creds.active,
@@ -2965,9 +3029,9 @@ Just type a message to chat with the AI agent.",
                                                                     memory.clone(),
                                                                     new_tools,
                                                                     agent.model().to_string(),
-                                                                    Some(build_system_prompt()),
+                                                                    Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                     max_turns, max_ctx, max_rounds, max_task_duration, max_spend,
-                                                                ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                                ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                                 *agent_state.write().await = Some(new_agent);
                                                             }
                                                             mcp_mgr.take_tools_changed();
@@ -2994,9 +3058,9 @@ Just type a message to chat with the AI agent.",
                                                             memory.clone(),
                                                             new_tools,
                                                             agent.model().to_string(),
-                                                            Some(build_system_prompt()),
+                                                            Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                             max_turns, max_ctx, max_rounds, max_task_duration, max_spend,
-                                                        ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                        ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                         *agent_state.write().await = Some(new_agent);
                                                     }
                                                     mcp_mgr.take_tools_changed();
@@ -3021,9 +3085,9 @@ Just type a message to chat with the AI agent.",
                                                             memory.clone(),
                                                             new_tools,
                                                             agent.model().to_string(),
-                                                            Some(build_system_prompt()),
+                                                            Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                             max_turns, max_ctx, max_rounds, max_task_duration, max_spend,
-                                                        ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                        ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                         *agent_state.write().await = Some(new_agent);
                                                     }
                                                     mcp_mgr.take_tools_changed();
@@ -3094,13 +3158,13 @@ Just type a message to chat with the AI agent.",
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 prov.model.clone(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns,
                                                                 max_ctx,
                                                                 max_rounds,
                                                                 max_task_duration,
                                                                 max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             *agent_state.write().await = Some(new_agent);
                                                             tracing::info!(
                                                                 provider = %prov.name,
@@ -3569,13 +3633,13 @@ Just type a message to chat with the AI agent.",
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 model.clone(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns,
                                                                 max_ctx,
                                                                 max_rounds,
                                                                 max_task_duration,
                                                                 max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             *agent_state.write().await = Some(new_agent);
                                                             let reply = temm1e_core::types::message::OutboundMessage {
                                                                 chat_id: msg.chat_id.clone(),
@@ -3681,13 +3745,13 @@ Just type a message to chat with the AI agent.",
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 mdl.clone(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns,
                                                                 max_ctx,
                                                                 max_rounds,
                                                                 max_task_duration,
                                                                 max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             *agent_state.write().await = Some(new_agent);
                                                             let key_count = keys.len();
                                                             let reply = temm1e_core::types::message::OutboundMessage {
@@ -4025,9 +4089,9 @@ Just type a message to chat with the AI agent.",
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 agent.model().to_string(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns, max_ctx, max_rounds, max_task_duration, max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             let fallback_cancel = cancel_token_clone.clone();
                                                             match fallback_agent.process_message(&msg, &mut session, Some(interrupt_clone.clone()), Some(pending_for_worker.clone()), None, None, Some(fallback_cancel)).await {
                                                                 Ok((mut reply, _usage)) => {
@@ -4156,13 +4220,13 @@ Just type a message to chat with the AI agent.",
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 new_model.clone(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns,
                                                                 max_ctx,
                                                                 max_rounds,
                                                                 max_task_duration,
                                                                 max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             *agent_state.write().await = Some(new_agent);
                                                             tracing::info!(provider = %new_name, model = %new_model, "Agent hot-reloaded (key validated)");
                                                         }
@@ -4209,9 +4273,9 @@ Just type a message to chat with the AI agent.",
                                                 memory.clone(),
                                                 new_tools,
                                                 agent.model().to_string(),
-                                                Some(build_system_prompt()),
+                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                 max_turns, max_ctx, max_rounds, max_task_duration, max_spend,
-                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                             *agent_state.write().await = Some(new_agent);
                                             tracing::info!("Agent rebuilt with updated MCP tools");
                                         }
@@ -4240,9 +4304,9 @@ Just type a message to chat with the AI agent.",
                                                 memory.clone(),
                                                 new_tools,
                                                 agent.model().to_string(),
-                                                Some(build_system_prompt()),
+                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                 max_turns, max_ctx, max_rounds, max_task_duration, max_spend,
-                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                             *agent_state.write().await = Some(new_agent);
                                             tracing::info!("Agent rebuilt with updated custom tools");
                                         }
@@ -4287,13 +4351,13 @@ Just type a message to chat with the AI agent.",
                                                                 memory.clone(),
                                                                 tools_template.clone(),
                                                                 model.clone(),
-                                                                Some(build_system_prompt()),
+                                                                Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                                 max_turns,
                                                                 max_ctx,
                                                                 max_rounds,
                                                                 max_task_duration,
                                                                 max_spend,
-                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
+                                                            ).with_v2_optimizations(v2_opt).with_parallel_phases(pp_opt).with_hive_enabled(hive_on).with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone()).with_shared_memory_strategy(shared_memory_strategy.clone()));
                                                             *agent_state.write().await = Some(new_agent);
 
                                                             if let Err(e) = save_credentials(provider_name, &api_key, &model, custom_base_url.as_deref()).await {
@@ -4643,6 +4707,8 @@ Just type a message to chat with the AI agent.",
             });
             let shared_mode: temm1e_tools::SharedMode =
                 Arc::new(tokio::sync::RwLock::new(config.mode));
+            let personality_profile: std::sync::Arc<temm1e_core::types::config::PersonalityProfile> =
+                std::sync::Arc::new(config.personality.clone());
             let shared_memory_strategy: Arc<
                 tokio::sync::RwLock<temm1e_core::types::config::MemoryStrategy>,
             > = Arc::new(tokio::sync::RwLock::new(
@@ -4658,6 +4724,7 @@ Just type a message to chat with the AI agent.",
                 Some(usage_store.clone()),
                 Some(shared_mode.clone()),
                 vault.clone(),
+                Some(personality_profile.clone()),
             );
             #[cfg(not(feature = "browser"))]
             let mut tools_template = temm1e_tools::create_tools(
@@ -4669,6 +4736,7 @@ Just type a message to chat with the AI agent.",
                 Some(usage_store.clone()),
                 Some(shared_mode.clone()),
                 vault.clone(),
+                Some(personality_profile.clone()),
             );
 
             // ── Custom script tools (user/agent-authored) ──────
@@ -4772,7 +4840,7 @@ Just type a message to chat with the AI agent.",
                     };
                     match provider_result {
                         Ok(provider) => {
-                            let system_prompt = Some(build_system_prompt());
+                            let system_prompt = Some(build_system_prompt_with_personality(Some(&*personality_profile)));
                             let consciousness_provider = provider.clone();
                             let mut rt = temm1e_agent::AgentRuntime::with_limits(
                                 provider,
@@ -4789,7 +4857,7 @@ Just type a message to chat with the AI agent.",
                             .with_v2_optimizations(v2_opt)
                             .with_parallel_phases(pp_opt)
                             .with_hive_enabled(hive_enabled_early)
-                            .with_shared_mode(shared_mode.clone())
+                            .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                             .with_shared_memory_strategy(shared_memory_strategy.clone());
                             // Tem Conscious: enable consciousness for CLI chat
                             tracing::info!(
@@ -4816,6 +4884,7 @@ Just type a message to chat with the AI agent.",
                                         consciousness_cfg,
                                         consciousness_provider.clone(),
                                         model.clone(),
+                                        Some(personality_profile.clone()),
                                     ),
                                 );
                             }
@@ -4887,7 +4956,7 @@ Just type a message to chat with the AI agent.",
                                             memory.clone(),
                                             tools_template.clone(),
                                             model.clone(),
-                                            Some(build_system_prompt()),
+                                            Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                             max_turns,
                                             max_ctx,
                                             max_rounds,
@@ -4897,7 +4966,7 @@ Just type a message to chat with the AI agent.",
                                         .with_v2_optimizations(v2_opt)
                                         .with_parallel_phases(pp_opt)
                                         .with_hive_enabled(hive_enabled_early)
-                                        .with_shared_mode(shared_mode.clone())
+                                        .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                         .with_shared_memory_strategy(shared_memory_strategy.clone())
                                         .with_perpetuum_temporal(cli_perpetuum_temporal.clone());
                                         if config.consciousness.enabled {
@@ -4911,6 +4980,7 @@ Just type a message to chat with the AI agent.",
                                                     },
                                                     consciousness_provider.clone(),
                                                     model.clone(),
+                                                    Some(personality_profile.clone()),
                                                 ),
                                             );
                                         }
@@ -4955,7 +5025,7 @@ Just type a message to chat with the AI agent.",
                                         model.clone(),
                                         token_store,
                                     ));
-                                let system_prompt = Some(build_system_prompt());
+                                let system_prompt = Some(build_system_prompt_with_personality(Some(&*personality_profile)));
                                 agent_opt = Some(
                                     temm1e_agent::AgentRuntime::with_limits(
                                         provider,
@@ -4971,7 +5041,7 @@ Just type a message to chat with the AI agent.",
                                     )
                                     .with_v2_optimizations(v2_opt)
                                     .with_parallel_phases(pp_opt)
-                                    .with_shared_mode(shared_mode.clone())
+                                    .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                     .with_shared_memory_strategy(shared_memory_strategy.clone()),
                                 );
                                 println!(
@@ -5240,7 +5310,7 @@ Just type a message to chat with the AI agent.",
                                                     memory.clone(),
                                                     new_tools,
                                                     agent.model().to_string(),
-                                                    Some(build_system_prompt()),
+                                                    Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                                     max_turns,
                                                     max_ctx,
                                                     max_rounds,
@@ -5249,7 +5319,7 @@ Just type a message to chat with the AI agent.",
                                                 )
                                                 .with_v2_optimizations(v2_opt)
                                                 .with_parallel_phases(pp_opt)
-                                                .with_shared_mode(shared_mode.clone())
+                                                .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                                 .with_shared_memory_strategy(
                                                     shared_memory_strategy.clone(),
                                                 ),
@@ -5290,7 +5360,7 @@ Just type a message to chat with the AI agent.",
                                             memory.clone(),
                                             new_tools,
                                             agent.model().to_string(),
-                                            Some(build_system_prompt()),
+                                            Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                             max_turns,
                                             max_ctx,
                                             max_rounds,
@@ -5299,7 +5369,7 @@ Just type a message to chat with the AI agent.",
                                         )
                                         .with_v2_optimizations(v2_opt)
                                         .with_parallel_phases(pp_opt)
-                                        .with_shared_mode(shared_mode.clone())
+                                        .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                         .with_shared_memory_strategy(
                                             shared_memory_strategy.clone(),
                                         ),
@@ -5335,7 +5405,7 @@ Just type a message to chat with the AI agent.",
                                             memory.clone(),
                                             new_tools,
                                             agent.model().to_string(),
-                                            Some(build_system_prompt()),
+                                            Some(build_system_prompt_with_personality(Some(&*personality_profile))),
                                             max_turns,
                                             max_ctx,
                                             max_rounds,
@@ -5344,7 +5414,7 @@ Just type a message to chat with the AI agent.",
                                         )
                                         .with_v2_optimizations(v2_opt)
                                         .with_parallel_phases(pp_opt)
-                                        .with_shared_mode(shared_mode.clone())
+                                        .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                         .with_shared_memory_strategy(
                                             shared_memory_strategy.clone(),
                                         ),
@@ -5548,7 +5618,7 @@ Just type a message to chat with the AI agent.",
                                         {
                                             eprintln!("Failed to save credentials: {}", e);
                                         }
-                                        let system_prompt = Some(build_system_prompt());
+                                        let system_prompt = Some(build_system_prompt_with_personality(Some(&*personality_profile)));
                                         agent_opt = Some(
                                             temm1e_agent::AgentRuntime::with_limits(
                                                 validated_provider,
@@ -5564,7 +5634,7 @@ Just type a message to chat with the AI agent.",
                                             )
                                             .with_v2_optimizations(v2_opt)
                                             .with_parallel_phases(pp_opt)
-                                            .with_shared_mode(shared_mode.clone())
+                                            .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                             .with_shared_memory_strategy(
                                                 shared_memory_strategy.clone(),
                                             ),
@@ -5620,7 +5690,7 @@ Just type a message to chat with the AI agent.",
                             {
                                 eprintln!("Failed to save credentials: {}", e);
                             }
-                            let system_prompt = Some(build_system_prompt());
+                            let system_prompt = Some(build_system_prompt_with_personality(Some(&*personality_profile)));
                             agent_opt = Some(
                                 temm1e_agent::AgentRuntime::with_limits(
                                     validated_provider,
@@ -5637,7 +5707,7 @@ Just type a message to chat with the AI agent.",
                                 .with_v2_optimizations(v2_opt)
                                 .with_parallel_phases(pp_opt)
                                 .with_hive_enabled(hive_enabled_early)
-                                .with_shared_mode(shared_mode.clone())
+                                .with_shared_mode(shared_mode.clone()).with_personality(personality_profile.clone())
                                 .with_shared_memory_strategy(shared_memory_strategy.clone()),
                             );
                             println!(


### PR DESCRIPTION
## Summary

This PR makes TEMM1E's hardcoded personality fully configurable through a `[personality]` TOML section, while preserving 100% backwards compatibility — existing deployments with no `[personality]` section behave identically to before.

- **New `PersonalityProfile` struct** in `temm1e-core` with all-optional fields (`name`, `nickname`, `identity`, `mode_prompts`, `classifier_description`, `consciousness_identity`, `gateway_system_prompt`, `mode_switch_messages`, `classifier_mode_rules`)
- **Threaded through all 7 prompt injection sites** where personality was previously hardcoded: `SystemPromptBuilder`, `AgentRuntime` mode blocks, LLM classifier, consciousness engine, mode switch tool, and gateway system prompt
- **Setup wizard integration** — both CLI (`temm1e setup`) and TUI onboarding now offer an optional personality customization step (default TEMM1E or custom name/nickname)
- **Accessor methods with built-in defaults** — every field falls back to the existing TEMM1E personality text when not configured

### Example TOML

```toml
[personality]
name = "ARIA"
nickname = "Aria"
identity = """
You are ARIA — an Autonomous Research and Intelligence Assistant.
You communicate clearly and value accuracy above all else.
"""
classifier_description = "an AI research assistant — methodical, curious, never sycophantic"
consciousness_identity = "consciousness layer of an AI agent called Aria"

[personality.mode_prompts]
play = "=== ARIA MODE: CASUAL ===\nYou are ARIA in casual mode.\n=== END MODE ==="
work = "=== ARIA MODE: RESEARCH ===\nYou are ARIA in research mode.\n=== END MODE ==="
```

### Motivation

The current personality (name, species, traits, values, communication rules) is hardcoded across 10+ files as string literals. This makes it impossible for users or forks to customize the agent's identity without modifying source code. This change extracts all personality text into a single configurable section while keeping the existing TEMM1E personality as the default.

### Files changed (14)

| File | Change |
|------|--------|
| `temm1e-core/types/config.rs` | New `PersonalityProfile` struct + accessors + `Temm1eConfig` field |
| `temm1e-agent/prompt_optimizer.rs` | Thread personality into `SystemPromptBuilder` + `section_identity()` |
| `temm1e-agent/runtime.rs` | Thread personality into `AgentRuntime` + `mode_prompt_block()` |
| `temm1e-agent/llm_classifier.rs` | Parameterize classifier prompts with personality |
| `temm1e-agent/consciousness_engine.rs` | Thread personality into observer prompts |
| `temm1e-tools/mode_switch.rs` | Thread personality into tool confirmation messages |
| `temm1e-tools/lib.rs` | Pass personality through tool factory functions |
| `temm1e-tui/onboarding/steps.rs` | New personality selection step |
| `temm1e-tui/views/onboarding.rs` | Render personality config screens |
| `temm1e-tui/app.rs` | State machine for personality onboarding flow |
| `temm1e-tui/lib.rs` | Apply personality to agent config on save |
| `temm1e-tui/agent_bridge.rs` | Pass personality to tool creation |
| `temm1e-agent/context.rs` | Pass personality to tiered prompt builder |
| `src/main.rs` | Create `Arc<PersonalityProfile>` at startup, wire everywhere, add CLI wizard step |

## Test plan

- [x] `cargo check --workspace` — compiles cleanly
- [x] `cargo clippy --workspace --all-targets` — no new warnings
- [x] All existing unit tests pass (modified crates: temm1e-core, temm1e-agent, temm1e-tools)
- [ ] Manual: run with no `[personality]` config — verify identical behavior
- [x] Manual: add `[personality] name = "TestBot"` — verify prompts use custom name
- [x] Manual: run `temm1e setup` — verify personality step appears between channel and provider