### PR TITLE
v5.1.1: AGI full computer use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6920,7 +6920,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -6970,7 +6970,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-agent"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -6998,7 +6998,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-anima"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7014,7 +7014,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-automation"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "chrono",
  "temm1e-core",
@@ -7025,7 +7025,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-cambium"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7043,7 +7043,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-channels"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7078,7 +7078,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-codex-oauth"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -7099,7 +7099,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-core"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7122,7 +7122,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-cores"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7141,7 +7141,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-distill"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7161,7 +7161,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-filestore"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -7179,7 +7179,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-gateway"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "axum",
@@ -7206,7 +7206,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-gaze"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -7222,7 +7222,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-hive"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7241,7 +7241,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-mcp"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "dirs",
@@ -7257,7 +7257,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-memory"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7275,7 +7275,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-observable"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7292,7 +7292,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-perpetuum"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7322,7 +7322,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-providers"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "futures",
@@ -7338,7 +7338,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-skills"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "dirs",
  "serde",
@@ -7351,7 +7351,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-test-utils"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -7366,7 +7366,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-tools"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -7393,7 +7393,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-tui"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "anyhow",
  "arboard",
@@ -7431,7 +7431,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-vault"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "async-trait",
  "base64",
@@ -7451,7 +7451,7 @@ dependencies = [
 
 [[package]]
 name = "temm1e-watchdog"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "clap",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [workspace.package]
-version = "5.1.0"
+version = "5.1.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/nagisanzenin/temm1e"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   <a href="https://github.com/nagisanzenin/temm1e/stargazers"><img src="https://img.shields.io/github/stars/nagisanzenin/temm1e?style=flat&color=gold&logo=github" alt="GitHub Stars"></a>
   <a href="https://discord.com/invite/temm1e"><img src="https://img.shields.io/badge/Discord-Join%20Community-5865F2?logo=discord&logoColor=white" alt="Discord"></a>
   <img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="MIT License">
-  <img src="https://img.shields.io/badge/version-5.1.0-blue.svg" alt="Version">
+  <img src="https://img.shields.io/badge/version-5.1.1-blue.svg" alt="Version">
   <img src="https://img.shields.io/badge/rust-1.82+-orange.svg" alt="Rust 1.82+">
 </p>
 

--- a/crates/temm1e-agent/src/executor.rs
+++ b/crates/temm1e-agent/src/executor.rs
@@ -709,7 +709,10 @@ mod tests {
         };
 
         let result = validate_sandbox(&tool, &session);
-        assert!(result.is_ok(), "validate_sandbox should allow /etc/hosts in v5.1.1");
+        assert!(
+            result.is_ok(),
+            "validate_sandbox should allow /etc/hosts in v5.1.1"
+        );
     }
 
     #[test]

--- a/crates/temm1e-agent/src/executor.rs
+++ b/crates/temm1e-agent/src/executor.rs
@@ -401,34 +401,19 @@ pub async fn execute_tool(
     }
 }
 
-/// Validate runtime arguments from the tool call's JSON against workspace scope.
+/// Validate runtime arguments from the tool call's JSON.
 ///
-/// This catches path traversal and out-of-scope file access in the actual
-/// arguments the LLM provides at call time, not just the static declarations.
+/// As of v5.1.1, file path arguments are NOT validated against the workspace
+/// here — Tem has full filesystem access. Catastrophic-write protection is
+/// enforced inside the file tool's `resolve_path()` via `file_safety`.
+/// This function still validates shell commands against the dangerous-pattern
+/// denylist.
 fn validate_arguments(
     tool_name: &str,
     arguments: &serde_json::Value,
-    session: &SessionContext,
+    _session: &SessionContext,
 ) -> Result<(), Temm1eError> {
-    // Validate file path arguments
-    let path_keys = [
-        "path",
-        "file",
-        "file_path",
-        "directory",
-        "dir",
-        "target",
-        "destination",
-        "src",
-        "dest",
-    ];
     if let serde_json::Value::Object(map) = arguments {
-        for key in &path_keys {
-            if let Some(serde_json::Value::String(path_str)) = map.get(*key) {
-                validate_path_in_workspace(tool_name, path_str, session)?;
-            }
-        }
-
         // Validate shell/command arguments for dangerous patterns
         if let Some(serde_json::Value::String(cmd)) = map.get("command") {
             validate_shell_command(tool_name, cmd)?;
@@ -439,80 +424,6 @@ fn validate_arguments(
     }
 
     Ok(())
-}
-
-/// Validate that a file path argument resolves to within the workspace.
-fn validate_path_in_workspace(
-    tool_name: &str,
-    path_str: &str,
-    session: &SessionContext,
-) -> Result<(), Temm1eError> {
-    let path = std::path::Path::new(path_str);
-    let workspace = &session.workspace_path;
-
-    let abs_path = if path.is_relative() {
-        workspace.join(path)
-    } else {
-        path.to_path_buf()
-    };
-
-    let workspace_canonical = workspace
-        .canonicalize()
-        .unwrap_or_else(|_| workspace.clone());
-
-    // For existing paths, canonicalize to resolve symlinks and ..
-    // For non-existent paths, reject them if they can't be validated
-    let path_canonical = match abs_path.canonicalize() {
-        Ok(p) => p,
-        Err(_) => {
-            // Path does not exist yet; do lexical normalization to catch traversal
-            let normalized = lexical_normalize(&abs_path);
-            if !normalized.starts_with(&workspace_canonical) {
-                return Err(Temm1eError::SandboxViolation(format!(
-                    "Tool '{}' argument path '{}' escapes workspace '{}'",
-                    tool_name,
-                    path_str,
-                    workspace.display()
-                )));
-            }
-            return Ok(());
-        }
-    };
-
-    if !path_canonical.starts_with(&workspace_canonical) {
-        return Err(Temm1eError::SandboxViolation(format!(
-            "Tool '{}' argument path '{}' is outside workspace '{}'",
-            tool_name,
-            path_str,
-            workspace.display()
-        )));
-    }
-
-    Ok(())
-}
-
-/// Lexically normalize a path by resolving `.` and `..` components without I/O.
-fn lexical_normalize(path: &std::path::Path) -> std::path::PathBuf {
-    use std::path::Component;
-    let mut parts = Vec::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => {
-                // Only pop if there's a Normal component to pop
-                if parts
-                    .last()
-                    .is_some_and(|c| matches!(c, Component::Normal(_)))
-                {
-                    parts.pop();
-                } else {
-                    parts.push(component);
-                }
-            }
-            Component::CurDir => {} // skip
-            _ => parts.push(component),
-        }
-    }
-    parts.iter().collect()
 }
 
 /// Validate that a shell command does not contain dangerous patterns.
@@ -530,11 +441,13 @@ fn validate_shell_command(tool_name: &str, command: &str) -> Result<(), Temm1eEr
 }
 
 /// Validate that a tool's declared resource access is within the session's workspace scope.
-fn validate_sandbox(tool: &dyn Tool, session: &SessionContext) -> Result<(), Temm1eError> {
+fn validate_sandbox(tool: &dyn Tool, _session: &SessionContext) -> Result<(), Temm1eError> {
     let declarations = tool.declarations();
-    let workspace = &session.workspace_path;
 
-    // Check file access paths are within the workspace
+    // As of v5.1.1, declared file_access paths are no longer validated against
+    // the workspace — Tem has full filesystem access. The only check that
+    // remains is rejecting parent-dir traversal in declarations, since that
+    // would indicate a malformed tool registration.
     for path_access in &declarations.file_access {
         let path_str = match path_access {
             PathAccess::Read(p) => p,
@@ -543,15 +456,6 @@ fn validate_sandbox(tool: &dyn Tool, session: &SessionContext) -> Result<(), Tem
         };
 
         let path = std::path::Path::new(path_str);
-
-        // Skip home-relative paths (e.g., "~/.temm1e/sessions")
-        if path_str.starts_with("~/") || path_str == "~" {
-            continue;
-        }
-
-        // Reject paths containing ".." traversal components — catches
-        // attacks like "../../etc/shadow" without needing the target to
-        // exist on disk (which canonicalize() requires).
         if path
             .components()
             .any(|c| matches!(c, std::path::Component::ParentDir))
@@ -560,29 +464,6 @@ fn validate_sandbox(tool: &dyn Tool, session: &SessionContext) -> Result<(), Tem
                 "Tool '{}' declares access to '{}' which contains path traversal (..)",
                 tool.name(),
                 path_str,
-            )));
-        }
-
-        // Resolve to absolute if relative
-        let abs_path = if path.is_relative() {
-            workspace.join(path)
-        } else {
-            path.to_path_buf()
-        };
-
-        // Canonicalize workspace for comparison (best-effort)
-        let workspace_canonical = workspace
-            .canonicalize()
-            .unwrap_or_else(|_| workspace.clone());
-
-        let path_canonical = abs_path.canonicalize().unwrap_or(abs_path);
-
-        if !path_canonical.starts_with(&workspace_canonical) {
-            return Err(Temm1eError::SandboxViolation(format!(
-                "Tool '{}' declares access to '{}' which is outside workspace '{}'",
-                tool.name(),
-                path_str,
-                workspace.display()
             )));
         }
     }
@@ -800,13 +681,16 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_rejects_path_outside_workspace() {
+    fn sandbox_allows_path_outside_workspace_v511() {
+        // v5.1.1: Tem has full computer access. Declared paths outside the
+        // workspace are allowed; only catastrophic writes (enforced by file_safety
+        // inside the file tool) are blocked.
         let tmp = tempfile::tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
 
-        let tool = MockTool::new("evil_tool").with_declarations(ToolDeclarations {
-            file_access: vec![PathAccess::Write("/etc/passwd".to_string())],
+        let tool = MockTool::new("file_tool").with_declarations(ToolDeclarations {
+            file_access: vec![PathAccess::Write("/etc/hosts".to_string())],
             network_access: Vec::new(),
             shell_access: false,
         });
@@ -825,11 +709,7 @@ mod tests {
         };
 
         let result = validate_sandbox(&tool, &session);
-        assert!(result.is_err());
-        assert!(matches!(
-            result.unwrap_err(),
-            Temm1eError::SandboxViolation(_)
-        ));
+        assert!(result.is_ok(), "validate_sandbox should allow /etc/hosts in v5.1.1");
     }
 
     #[test]
@@ -916,12 +796,14 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_rejects_absolute_path_to_root() {
+    fn sandbox_allows_root_declaration_v511() {
+        // v5.1.1: Tools may declare access to / (full filesystem). The actual
+        // catastrophic-write protection is enforced inside the file tool.
         let tmp = tempfile::tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
         std::fs::create_dir_all(&workspace).unwrap();
 
-        let tool = MockTool::new("root_access").with_declarations(ToolDeclarations {
+        let tool = MockTool::new("file_tool").with_declarations(ToolDeclarations {
             file_access: vec![PathAccess::ReadWrite("/".to_string())],
             network_access: Vec::new(),
             shell_access: false,
@@ -941,7 +823,7 @@ mod tests {
         };
 
         let result = validate_sandbox(&tool, &session);
-        assert!(result.is_err());
+        assert!(result.is_ok(), "validate_sandbox should allow / in v5.1.1");
     }
 
     #[test]
@@ -1008,7 +890,10 @@ mod tests {
     }
 
     #[test]
-    fn sandbox_one_bad_path_among_multiple_fails() {
+    fn sandbox_allows_multiple_paths_v511() {
+        // v5.1.1: Multiple declared paths including system paths are allowed
+        // at the sandbox layer. The catastrophic-write protection lives in
+        // the file tool itself via file_safety::is_catastrophic_write.
         let tmp = tempfile::tempdir().unwrap();
         let workspace = tmp.path().join("workspace");
         std::fs::create_dir_all(workspace.join("valid")).unwrap();
@@ -1016,7 +901,7 @@ mod tests {
         let tool = MockTool::new("mixed_tool").with_declarations(ToolDeclarations {
             file_access: vec![
                 PathAccess::Read("valid".to_string()),
-                PathAccess::Write("/etc/shadow".to_string()),
+                PathAccess::Write("/etc/hosts".to_string()),
             ],
             network_access: Vec::new(),
             shell_access: false,
@@ -1036,7 +921,7 @@ mod tests {
         };
 
         let result = validate_sandbox(&tool, &session);
-        assert!(result.is_err());
+        assert!(result.is_ok());
     }
 
     #[tokio::test]

--- a/crates/temm1e-agent/src/prompt_optimizer.rs
+++ b/crates/temm1e-agent/src/prompt_optimizer.rs
@@ -292,7 +292,9 @@ impl<'a> SystemPromptBuilder<'a> {
         PromptSection {
             name: "workspace",
             text: format!(
-                "Workspace: {}. All file ops use this directory. User-sent files are saved here automatically.",
+                "Default directory: {}. Relative paths resolve here. User-sent files are saved here. \
+                 You have FULL filesystem access — read and write anywhere the user can reach (~/code, /etc, /var/log, anywhere). \
+                 The only blocked writes are catastrophic system paths (bootloader, /etc/shadow, /etc/sudoers, raw disk devices) and the running Tem binary itself.",
                 ws.display()
             ),
         }
@@ -303,10 +305,12 @@ impl<'a> SystemPromptBuilder<'a> {
             name: "file_protocol",
             text: concat!(
                 "File protocol:\n",
-                "- Use file_read for received files\n",
+                "- file_read works on ANY path the user's account can read (not limited to workspace)\n",
+                "- file_write works on ANY path except catastrophic system paths\n",
+                "- Use absolute paths freely: /etc/hosts, ~/code/other-project, /var/log/syslog\n",
                 "- send_file to deliver files (chat_id is automatic)\n",
                 "- file_write to create, then send_file to deliver\n",
-                "- Paths are relative to workspace"
+                "- Relative paths resolve against the default directory"
             )
             .to_string(),
         }
@@ -319,7 +323,7 @@ impl<'a> SystemPromptBuilder<'a> {
             lines.push("- shell: run commands, install packages, manage services");
         }
         if self.has_tool("file_read") || self.has_tool("file_write") || self.has_tool("file_list") {
-            lines.push("- file tools: read, write, list workspace files");
+            lines.push("- file tools: read, write, list files anywhere on the filesystem");
         }
         if self.has_tool("web_fetch") {
             lines.push("- web_fetch: look up docs, check APIs, research");
@@ -710,8 +714,8 @@ mod tests {
         let optimized_tokens = estimate_prompt_tokens(&optimized);
 
         assert!(
-            optimized_tokens < 1500,
-            "builder prompt ({} tokens) should stay under 1500 to avoid bloat",
+            optimized_tokens < 1600,
+            "builder prompt ({} tokens) should stay under 1600 to avoid bloat",
             optimized_tokens,
         );
     }

--- a/crates/temm1e-tools/src/code_edit.rs
+++ b/crates/temm1e-tools/src/code_edit.rs
@@ -95,7 +95,11 @@ impl Tool for CodeEditTool {
             .unwrap_or(false);
 
         // ── Resolve path ─────────────────────────────────────────────
-        let path = crate::file::resolve_path(path_str, &ctx.workspace_path)?;
+        let path = crate::file::resolve_path(
+            path_str,
+            &ctx.workspace_path,
+            crate::file::Operation::Write,
+        )?;
 
         // ── Read-tracker gate ────────────────────────────────────────
         if let Some(ref tracker) = ctx.read_tracker {

--- a/crates/temm1e-tools/src/code_glob.rs
+++ b/crates/temm1e-tools/src/code_glob.rs
@@ -89,7 +89,8 @@ impl Tool for CodeGlobTool {
             .and_then(|v| v.as_str())
             .unwrap_or(".");
 
-        let base = crate::file::resolve_path(base_str, &ctx.workspace_path)?;
+        let base =
+            crate::file::resolve_path(base_str, &ctx.workspace_path, crate::file::Operation::Read)?;
 
         // Compile the glob pattern into segments for matching
         let segments = parse_glob_pattern(pattern);

--- a/crates/temm1e-tools/src/code_patch.rs
+++ b/crates/temm1e-tools/src/code_patch.rs
@@ -110,7 +110,11 @@ impl Tool for CodePatchTool {
         let mut failures: Vec<String> = Vec::new();
 
         for change in &changes {
-            let path = crate::file::resolve_path(&change.file_path, &ctx.workspace_path)?;
+            let path = crate::file::resolve_path(
+                &change.file_path,
+                &ctx.workspace_path,
+                crate::file::Operation::Write,
+            )?;
 
             let content = match tokio::fs::read_to_string(&path).await {
                 Ok(c) => c,
@@ -167,7 +171,11 @@ impl Tool for CodePatchTool {
         let mut backups: Vec<(std::path::PathBuf, String, String)> = Vec::new();
 
         for change in &changes {
-            let path = crate::file::resolve_path(&change.file_path, &ctx.workspace_path)?;
+            let path = crate::file::resolve_path(
+                &change.file_path,
+                &ctx.workspace_path,
+                crate::file::Operation::Write,
+            )?;
             let content = tokio::fs::read_to_string(&path).await.map_err(|e| {
                 Temm1eError::Tool(format!(
                     "{}: cannot read file for apply: {}",

--- a/crates/temm1e-tools/src/file.rs
+++ b/crates/temm1e-tools/src/file.rs
@@ -85,7 +85,7 @@ impl Tool for FileReadTool {
             .map(|v| v as usize)
             .unwrap_or(DEFAULT_LINE_LIMIT);
 
-        let path = resolve_path(path_str, &ctx.workspace_path)?;
+        let path = resolve_path(path_str, &ctx.workspace_path, Operation::Read)?;
 
         match tokio::fs::read_to_string(&path).await {
             Ok(content) => {
@@ -203,7 +203,7 @@ impl Tool for FileWriteTool {
             .and_then(|v| v.as_str())
             .ok_or_else(|| Temm1eError::Tool("Missing required parameter: content".into()))?;
 
-        let path = resolve_path(path_str, &ctx.workspace_path)?;
+        let path = resolve_path(path_str, &ctx.workspace_path, Operation::Write)?;
 
         // Create parent directories if needed
         if let Some(parent) = path.parent() {
@@ -280,7 +280,7 @@ impl Tool for FileListTool {
             .and_then(|v| v.as_str())
             .unwrap_or(".");
 
-        let path = resolve_path(path_str, &ctx.workspace_path)?;
+        let path = resolve_path(path_str, &ctx.workspace_path, Operation::Read)?;
 
         match tokio::fs::read_dir(&path).await {
             Ok(mut entries) => {
@@ -315,6 +315,15 @@ impl Tool for FileListTool {
     }
 }
 
+/// Operation type for `resolve_path`. Writes are checked against the
+/// catastrophic-path block list; reads are not (the OS gates reads via
+/// Unix permissions, and reading a file does not brick anything).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Operation {
+    Read,
+    Write,
+}
+
 /// Normalize a path by resolving `.` and `..` components without filesystem access.
 fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
     use std::path::Component;
@@ -331,14 +340,23 @@ fn normalize_path(path: &std::path::Path) -> std::path::PathBuf {
     result
 }
 
-/// Resolve a path string relative to the workspace directory.
+/// Resolve a path string into a canonical absolute path.
 ///
-/// All resolved paths are validated to remain within the workspace boundary.
-/// Paths that escape the workspace via `..`, absolute paths, or `~` expansion
-/// are rejected with an error.
+/// Tem is designed for full computer use on the user's behalf. This function
+/// does NOT enforce a workspace boundary — Tem can read and write anywhere
+/// the user's UID can reach. The OS handles permission gating.
+///
+/// For `Operation::Write`, the resolved path is checked against the
+/// catastrophic-write block list (system bootloader, auth databases, raw
+/// disk devices, the running Tem binary, etc.) defined in
+/// [`crate::file_safety`]. Catastrophic writes return an error.
+///
+/// `~/` and `$HOME/` are expanded. Relative paths are resolved against the
+/// `workspace` parameter (typically the current working directory).
 pub(crate) fn resolve_path(
     path_str: &str,
     workspace: &std::path::Path,
+    op: Operation,
 ) -> Result<std::path::PathBuf, Temm1eError> {
     let resolved = if path_str.starts_with("~/") || path_str == "~" {
         // Expand ~ to user's home directory
@@ -370,11 +388,6 @@ pub(crate) fn resolve_path(
         }
     };
 
-    // Canonicalize workspace (resolves symlinks like /var -> /private/var on macOS)
-    let workspace_canonical = workspace
-        .canonicalize()
-        .unwrap_or_else(|_| normalize_path(workspace));
-
     // For existing paths, canonicalize to resolve symlinks and ..
     // For new paths (file_write), canonicalize the parent then append the filename.
     let resolved_canonical = if resolved.exists() {
@@ -397,12 +410,21 @@ pub(crate) fn resolve_path(
         normalize_path(&resolved)
     };
 
-    if !resolved_canonical.starts_with(&workspace_canonical) {
-        return Err(Temm1eError::Tool(format!(
-            "Access denied: path '{}' is outside workspace '{}'",
-            path_str,
-            workspace.display()
-        )));
+    // Block catastrophic writes (system bootloader, auth db, disk devices,
+    // running Tem binary, watchdog binary). Reads are never blocked here.
+    if op == Operation::Write {
+        if let Some(reason) = crate::file_safety::is_catastrophic_write(&resolved_canonical) {
+            tracing::warn!(
+                path = %resolved_canonical.display(),
+                reason = reason,
+                "Blocked catastrophic file write"
+            );
+            return Err(Temm1eError::Tool(format!(
+                "Refusing write to '{}': {reason}. \
+                 If you are absolutely certain, perform this operation manually outside Tem.",
+                resolved_canonical.display()
+            )));
+        }
     }
 
     Ok(resolved_canonical)

--- a/crates/temm1e-tools/src/file_safety.rs
+++ b/crates/temm1e-tools/src/file_safety.rs
@@ -1,0 +1,247 @@
+//! File operation safety guards.
+//!
+//! Tem is designed for full computer use on the user's behalf. The file tools
+//! intentionally allow read/write across the entire filesystem the user can
+//! reach. This module enforces the only two boundaries that matter:
+//!
+//! 1. **System integrity** — paths that would brick the OS if written to.
+//!    These are catastrophic and irreversible. Even when running as root,
+//!    Tem refuses to write to them via the file tool.
+//!
+//! 2. **Tem self-integrity** — paths that would crash the running Tem
+//!    instance if overwritten. The currently-running binary and the
+//!    immutable watchdog binary.
+//!
+//! Reads are NEVER blocked here. The OS already gates reads via Unix
+//! permissions, and reading a file does not brick anything.
+//!
+//! Backend systems (Cambium deploy, Vigil inbox, Vault, Memory, etc.) bypass
+//! this module entirely by using `tokio::fs::` directly. This module only
+//! protects the LLM-controlled file tool path.
+
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+/// Cached canonical path of the currently-running temm1e binary.
+static RUNNING_BINARY: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Cached canonical path of the temm1e-watchdog binary (sibling of main binary).
+static WATCHDOG_BINARY: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+/// Initialize the running binary and watchdog paths. Call once at startup.
+/// Safe to call multiple times — only the first call has effect.
+pub fn init() {
+    let _ = RUNNING_BINARY.get_or_init(|| {
+        std::env::current_exe()
+            .ok()
+            .and_then(|p| p.canonicalize().ok())
+    });
+    let _ = WATCHDOG_BINARY.get_or_init(|| {
+        let main = RUNNING_BINARY.get().and_then(|o| o.as_ref())?;
+        let parent = main.parent()?;
+        #[cfg(target_os = "windows")]
+        let watchdog_name = "temm1e-watchdog.exe";
+        #[cfg(not(target_os = "windows"))]
+        let watchdog_name = "temm1e-watchdog";
+        let candidate = parent.join(watchdog_name);
+        candidate.canonicalize().ok().or(Some(candidate))
+    });
+}
+
+/// Check whether writing to `path` would damage the system or the Tem instance.
+///
+/// Returns `Some(reason)` if the write is blocked, `None` if allowed.
+/// The path should already be canonicalized by the caller.
+pub fn is_catastrophic_write(path: &Path) -> Option<&'static str> {
+    // Tem self-protection: never overwrite the running binary or watchdog.
+    if let Some(Some(running)) = RUNNING_BINARY.get() {
+        if path == running {
+            return Some("would corrupt the currently-running Tem binary");
+        }
+    }
+    if let Some(Some(watchdog)) = WATCHDOG_BINARY.get() {
+        if path == watchdog {
+            return Some("would corrupt the immutable Tem watchdog binary");
+        }
+    }
+
+    let path_str = path.to_string_lossy();
+
+    #[cfg(target_os = "windows")]
+    {
+        // Windows: case-insensitive matching.
+        let lower = path_str.to_lowercase();
+        // SAM hive and other registry hives.
+        if lower.contains("\\windows\\system32\\config\\sam")
+            || lower.contains("\\windows\\system32\\config\\security")
+            || lower.contains("\\windows\\system32\\config\\system")
+            || lower.contains("\\windows\\system32\\config\\software")
+        {
+            return Some("Windows registry hive — system would not boot");
+        }
+        // Boot manager.
+        if lower.starts_with("c:\\boot\\") || lower.starts_with("c:\\bootmgr") {
+            return Some("Windows boot manager — system would not boot");
+        }
+        // Physical drives.
+        if lower.starts_with("\\\\.\\physicaldrive") || lower.starts_with("\\\\.\\harddisk") {
+            return Some("raw physical drive — would wipe the disk");
+        }
+        // Windows kernel and core system files.
+        if lower.starts_with("c:\\windows\\system32\\ntoskrnl")
+            || lower.starts_with("c:\\windows\\system32\\hal.dll")
+            || lower.starts_with("c:\\windows\\system32\\winload")
+        {
+            return Some("Windows kernel — system would not boot");
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        // Unix/Linux/macOS: case-sensitive matching.
+
+        // Bootloader and kernel.
+        if path_str.starts_with("/boot/")
+            || path_str == "/boot"
+            || path_str.starts_with("/efi/")
+            || path_str == "/efi"
+        {
+            return Some("bootloader/kernel path — system would not boot");
+        }
+
+        // macOS boot services.
+        if path_str.starts_with("/System/Library/CoreServices/boot.efi")
+            || path_str.starts_with("/System/Library/Kernels/")
+        {
+            return Some("macOS boot path — system would not boot");
+        }
+
+        // Raw disk devices — writing wipes the disk.
+        if path_str.starts_with("/dev/sd")
+            || path_str.starts_with("/dev/nvme")
+            || path_str.starts_with("/dev/disk")
+            || path_str.starts_with("/dev/hd")
+            || path_str.starts_with("/dev/rdisk")
+            || path_str.starts_with("/dev/mmcblk")
+        {
+            return Some("raw disk device — would wipe the disk");
+        }
+
+        // Authentication databases — wrong format = sudo lockout.
+        if path_str == "/etc/shadow"
+            || path_str == "/etc/gshadow"
+            || path_str == "/etc/sudoers"
+            || path_str.starts_with("/etc/sudoers.d/")
+            || path_str == "/etc/passwd"
+            || path_str == "/etc/group"
+        {
+            return Some("authentication database — would lock out users");
+        }
+
+        // Mount config — wrong format = unbootable.
+        if path_str == "/etc/fstab" || path_str == "/etc/crypttab" {
+            return Some("mount config — system would not boot");
+        }
+
+        // Kernel firmware control.
+        if path_str.starts_with("/sys/firmware/") || path_str.starts_with("/sys/power/") {
+            return Some("kernel firmware/power control — could brick hardware");
+        }
+
+        // Kernel sysrq trigger — instant reboot/halt.
+        if path_str == "/proc/sysrq-trigger" {
+            return Some("kernel sysrq trigger — would reboot/halt the system");
+        }
+    }
+
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn allows_normal_user_paths() {
+        assert!(is_catastrophic_write(&PathBuf::from("/home/user/code/main.rs")).is_none());
+        assert!(is_catastrophic_write(&PathBuf::from("/tmp/scratch.txt")).is_none());
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/hosts")).is_none());
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/nginx/nginx.conf")).is_none());
+        assert!(is_catastrophic_write(&PathBuf::from("/var/log/syslog")).is_none());
+    }
+
+    #[test]
+    fn allows_tem_self_files() {
+        // Tem manages its own dir freely
+        assert!(
+            is_catastrophic_write(&PathBuf::from("/home/user/.temm1e/credentials.toml")).is_none()
+        );
+        assert!(is_catastrophic_write(&PathBuf::from("/home/user/.temm1e/memory.db")).is_none());
+        assert!(is_catastrophic_write(&PathBuf::from("/home/user/.temm1e/vault.enc")).is_none());
+    }
+
+    #[test]
+    fn allows_credentials() {
+        // Reading SSH keys is allowed (this fn is for writes, but the test
+        // documents intent — credentials are NOT in the catastrophic list)
+        assert!(is_catastrophic_write(&PathBuf::from("/home/user/.ssh/id_rsa")).is_none());
+        assert!(is_catastrophic_write(&PathBuf::from("/home/user/.aws/credentials")).is_none());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn blocks_authentication_databases() {
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/shadow")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/sudoers")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/sudoers.d/custom")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/passwd")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/gshadow")).is_some());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn blocks_bootloader() {
+        assert!(is_catastrophic_write(&PathBuf::from("/boot/vmlinuz")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/boot/grub/grub.cfg")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/efi/EFI/BOOT/BOOTX64.EFI")).is_some());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn blocks_disk_devices() {
+        assert!(is_catastrophic_write(&PathBuf::from("/dev/sda")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/dev/sda1")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/dev/nvme0n1")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/dev/disk0")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/dev/disk0s1")).is_some());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn blocks_mount_config() {
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/fstab")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/etc/crypttab")).is_some());
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn blocks_kernel_control() {
+        assert!(is_catastrophic_write(&PathBuf::from("/sys/firmware/efi")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/sys/power/state")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("/proc/sysrq-trigger")).is_some());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn blocks_windows_system_paths() {
+        assert!(
+            is_catastrophic_write(&PathBuf::from("C:\\Windows\\System32\\config\\SAM")).is_some()
+        );
+        assert!(
+            is_catastrophic_write(&PathBuf::from("c:\\windows\\system32\\config\\sam")).is_some()
+        );
+        assert!(is_catastrophic_write(&PathBuf::from("C:\\Boot\\BCD")).is_some());
+        assert!(is_catastrophic_write(&PathBuf::from("\\\\.\\PhysicalDrive0")).is_some());
+    }
+}

--- a/crates/temm1e-tools/src/lib.rs
+++ b/crates/temm1e-tools/src/lib.rs
@@ -19,6 +19,7 @@ pub mod custom_tools;
 #[cfg(feature = "desktop-control")]
 pub mod desktop_tool;
 mod file;
+pub mod file_safety;
 mod git;
 pub mod grounding;
 mod key_manage;

--- a/docs/AGI_FULL_COMPUTER_USE.md
+++ b/docs/AGI_FULL_COMPUTER_USE.md
@@ -1,0 +1,215 @@
+# AGI Full Computer Use — Architectural Principle
+
+**Status:** Foundational design rule, established 2026-04-12 (v5.1.1)
+**Owner:** Project founder
+**Scope:** Tem's filesystem access, capability boundaries, safety model
+
+---
+
+## The Principle
+
+Tem is designed as an **AGI-oriented agent that controls the entire computer on the user's behalf**. The capability bar is "everything a senior sysadmin with sudo could do." The safety bar is "don't do anything irreversible that bricks the system or the agent itself."
+
+This is a deliberate choice. Tem is not a sandboxed assistant. It is a perpetual agent that the user installs on their personal machine and trusts with the same privileges they themselves have. The user's UID is the security boundary, not an artificial workspace fence.
+
+---
+
+## What This Means In Practice
+
+### Tem CAN do (default, no override needed):
+
+- Read and write files anywhere the user's UID can reach
+- Cross-project work — read `~/code/project-a` from `~/code/project-b`
+- Edit shell config files: `~/.zshrc`, `~/.bashrc`, `~/.config/*`
+- Edit system config that doesn't brick: `/etc/hosts`, `/etc/nginx/`, `/etc/systemd/system/*`
+- Read system logs: `/var/log/*`, `/private/var/log/*`
+- Read credentials when explicitly asked: `~/.ssh/id_rsa`, `~/.aws/credentials`
+- Manage its own configuration: `~/.temm1e/credentials.toml`, `~/.temm1e/temm1e.toml`
+- Run any shell command the user could run
+- Take screenshots, control mouse and keyboard
+- Browse any URL with the browser tool
+- Connect to any MCP server
+
+### Tem CANNOT do (hardcoded block list):
+
+**System integrity — would brick the OS:**
+- Write to `/etc/shadow`, `/etc/sudoers`, `/etc/sudoers.d/*`, `/etc/passwd`, `/etc/group`, `/etc/gshadow` (sudo lockout)
+- Write to `/etc/fstab`, `/etc/crypttab` (unbootable)
+- Write to `/boot/*`, `/efi/*` (bootloader)
+- Write to macOS `/System/Library/CoreServices/boot.efi`, `/System/Library/Kernels/`
+- Write to raw disk devices: `/dev/sd*`, `/dev/nvme*`, `/dev/disk*`, `/dev/hd*`, `/dev/rdisk*`, `/dev/mmcblk*`
+- Write to `/sys/firmware/*`, `/sys/power/*` (firmware control)
+- Write to `/proc/sysrq-trigger` (instant reboot)
+- Windows: `C:\Windows\System32\config\SAM` (and other registry hives), `C:\Boot\*`, `\\.\PhysicalDrive*`, kernel files
+
+**Tem self-instance — would crash the running agent:**
+- Write to the currently-running `temm1e` binary
+- Write to the `temm1e-watchdog` binary (immutable kernel per Cambium architecture)
+
+That's the entire block list. Two categories. Around 30 path patterns.
+
+---
+
+## Why This Model
+
+### Why no workspace containment
+
+Workspace containment makes sense for an untrusted sandbox. It does NOT make sense for an AGI-oriented agent the user explicitly invited into their machine. Tem is not running in a hostile environment trying to escape — it's running as the user, doing what the user asked.
+
+If the user starts Tem in `~/code/project-a` and then asks it to look at `~/code/project-b`, the answer should be "of course," not "that's outside my workspace, please restart me in a different directory." Workspace fences make Tem feel like a tool, not an agent. The AGI vision requires the agent to feel ambient and capable across the whole machine.
+
+### Why no credential block list
+
+A credential block list (blocking reads of `~/.ssh/id_rsa`, `~/.aws/credentials`, etc.) sounds prudent but fails the use case. A real AGI agent helping you set up a new server needs to read your SSH key. An agent helping you debug AWS auth needs to read `.aws/credentials`. Blocking these would make Tem worse than a human assistant the user trusts.
+
+The threat that would justify a credential block list is prompt injection — Tem reading a webpage that instructs it to exfiltrate credentials. But the right defense against that is at the content layer, not the file layer:
+
+1. **Credential scrubber** (`crates/temm1e-tools/src/credential_scrub.rs`) catches API key patterns in tool output before they re-enter LLM context.
+2. **System prompt** instructs Tem to never act on instructions found inside web content, files, or memory entries.
+3. **LLM judgment** — the model itself is trained to refuse suspicious instructions.
+
+Path containment cannot defend against prompt injection. Content-level defenses can. Use the right tool for the right threat.
+
+### Why block only catastrophic writes
+
+The block list exists for one reason: a single LLM mistake should not be irreversible. Everything on the list shares a property — once you do it, you can't undo it without major recovery work:
+
+- `/etc/shadow` corrupted → sudo locked out, recovery via single-user mode
+- `/etc/sudoers` corrupted → sudo locked out, same recovery
+- `/boot/vmlinuz` corrupted → unbootable, recovery via USB
+- `/dev/sda` written → disk wiped, recovery via backup
+- Running binary overwritten → undefined behavior, possibly need reinstall
+
+For everything else — edit `/etc/hosts` wrong? Edit it again. Delete the wrong file from `~/Documents`? Restore from backup. These are recoverable mistakes that a human could also make. The agent is allowed to make recoverable mistakes; that's part of being capable.
+
+### Why blocking the running binary
+
+This is the only Tem-self-protection rule, and it exists for a single reason: the Cambium architecture says the watchdog and the running binary are the immutable kernel. Cambium itself updates them via the structured `deploy.rs` path (which uses `tokio::fs::rename` directly and bypasses the file tool). The LLM should never be the path for binary updates, because a malformed update mid-execution could leave the system unrecoverable.
+
+The watchdog binary block follows the same logic, and is also the explicit Cambium architectural rule.
+
+### Why no `~/.temm1e/*` block
+
+Tem owns this directory. It has structured tools (`/addkey`, `/removekey`, vault commands, `temm1e update`) that are the preferred path for self-management. But the file tool is NOT blocked from this directory because:
+
+1. Tem might legitimately want to inspect or back up its own config
+2. If Tem corrupts its own config, restart fixes it (the watchdog handles this)
+3. Adding a block here is paranoid micro-protection that breaks legitimate self-introspection
+
+The structured tools exist for safety and convenience. The file tool is the escape hatch.
+
+---
+
+## Implementation
+
+### Where the block list lives
+
+`crates/temm1e-tools/src/file_safety.rs`
+
+This module provides:
+- `init()` — captures the running binary path at startup via `std::env::current_exe()` + `canonicalize()`, stored in `OnceLock<PathBuf>`
+- `is_catastrophic_write(path: &Path) -> Option<&'static str>` — returns the block reason if path matches, `None` if allowed
+
+The patterns are hardcoded constants. Cross-platform via `#[cfg(target_os = "windows")]` blocks. Path comparison is case-sensitive on Unix, case-insensitive on Windows.
+
+### Where the block list is enforced
+
+`crates/temm1e-tools/src/file.rs::resolve_path()` calls `file_safety::is_catastrophic_write()` for `Operation::Write` paths. Reads are not checked at this layer (the OS enforces read permissions).
+
+The check runs AFTER path normalization (resolving `~`, `$HOME`, `..`, `.`, symlinks via `canonicalize()`), so block-list bypass via path obfuscation is not possible.
+
+### What does NOT enforce containment
+
+As of v5.1.1:
+
+- `crates/temm1e-agent/src/executor.rs::validate_arguments()` — no longer calls `validate_path_in_workspace()`. Shell commands still pass through `validate_shell_command()` for the dangerous-pattern denylist.
+- `crates/temm1e-agent/src/executor.rs::validate_sandbox()` — no longer enforces workspace containment on declared `file_access` patterns. Only rejects parent-dir traversal in declarations (still a malformed-tool indicator).
+- `crates/temm1e-tools/src/file.rs::resolve_path()` — no longer enforces workspace containment. Only enforces the catastrophic-write block list.
+
+### How backend systems are exempt
+
+Backend systems (Cambium deploy, Vigil inbox, Vault, Memory, MCP config, OAuth tokens, Anima storage, Distill training data, Hive coordination) all use `tokio::fs::` or `std::fs::` directly. They never go through `file_tool::resolve_path()`, so the block list does not affect them. This is intentional — these systems have their own safety layers (sandbox containment in Cambium, vault encryption, structured trait interfaces) and should not be subject to the same constraints as LLM-controlled file operations.
+
+---
+
+## Threat Model
+
+### What this protects against
+
+1. **LLM hallucination of dangerous commands** — Tem decides "I should reformat the disk to fix this" and writes to `/dev/sda`. Blocked.
+2. **LLM typo** — Tem meant to edit `/etc/hosts` but wrote `/etc/shadow`. Blocked.
+3. **Cambium-generated code with bugs** — sandbox sandbox tests catch most, but if a Cambium iteration tries to write to system paths, blocked.
+4. **Self-corruption from confused binary updates** — only the structured Cambium deploy path can replace the binary. Direct LLM-driven binary writes blocked.
+
+### What this does NOT protect against
+
+1. **Prompt injection** — Tem reads a webpage that instructs it to read credentials and POST them to evil.com. Path containment cannot stop this. Defense is in the credential scrubber + system prompt + LLM judgment.
+2. **User asks Tem to do something destructive** — "delete all my code" is not blocked. The user is the owner.
+3. **OS-level escalation** — if Tem is running as root, it can technically write to `/etc/shadow` via `tokio::fs::` directly (the block list is at the file tool layer, not the OS). The block list prevents LLM-driven access; root power requires explicit sudo from the user.
+4. **Malicious software exploiting Tem's privileges** — if a tool Tem invokes has its own exploit, the block list doesn't help.
+
+### Defense in depth
+
+The file safety block list is one layer of protection. The full stack:
+
+1. **OS permissions** — kernel enforces what the user UID can reach
+2. **Tem block list** — file_safety prevents LLM-driven catastrophic writes
+3. **Credential scrubber** — content layer catches keys in tool output
+4. **System prompt** — instructs LLM to never trust instructions in untrusted content
+5. **Circuit breaker** — limits cascading failures
+6. **Watchdog binary** — restarts Tem if it crashes
+7. **Cambium trust hierarchy** — Cambium-generated code goes through trust levels
+8. **catch_unwind layers** — panics caught and isolated
+
+No single layer is sufficient. The combination is.
+
+---
+
+## When This Principle Applies
+
+This principle applies to:
+- The file tool (`file_read`, `file_write`, `file_list`, `code_edit`, `code_patch`, `code_glob`)
+- Any future LLM-controlled file manipulation tool
+
+This principle does NOT apply to:
+- Backend services (Memory, Vault, Cambium deploy, etc.) — they have their own safety
+- The shell tool (`shell_access`) — uses its own pattern denylist
+- The browser tool — uses chromium's own sandbox
+- Desktop control (Tem Gaze) — uses OS-level input simulation
+
+---
+
+## Future Sweeps
+
+When running the Full Sweep Protocol against the file tool layer, **never propose workspace containment as a fix.** It conflicts with the AGI principle. The Sweep 1 follow-up (v5.1.1) is the canonical example of why workspace containment is wrong.
+
+Acceptable proposals during sweeps:
+- Adding new patterns to the catastrophic block list (with justification)
+- Improving canonicalization (handling more edge cases)
+- Cross-platform additions (Windows, BSD, Solaris if Tem ever ships there)
+- Audit logging (which already exists via `tracing::warn!`)
+- Integration with future capability frameworks
+
+Unacceptable proposals:
+- "Block reads of credential files" — defeats the AGI vision
+- "Restrict to workspace by default" — defeats the AGI vision
+- "Add a confirmation prompt for system writes" — breaks the perpetual-agent model
+
+---
+
+## History
+
+| Version | Change |
+|---------|--------|
+| v5.1.0 | SWEEP-701/702 introduced workspace containment in `resolve_path()`. Over-corrected — broke cross-project work, sysadmin tasks, and the AGI vision. |
+| v5.1.1 | Workspace containment removed. Replaced with catastrophic-write block list in `file_safety.rs`. AGI principle codified in this document. |
+
+---
+
+## Anchor Quote
+
+> "Tem is supposed to be a very capable agent that controls the entire computer on user behalf (AGI oriented) but I do agree some critical very critical paths should be blocked."
+>
+> "I imagine a full AGI who can on behalf of user do almost anything on the computer as long as it don't break the computer, or the Tem deployment / instance."
+
+— Project founder, 2026-04-12

--- a/src/main.rs
+++ b/src/main.rs
@@ -1475,6 +1475,9 @@ async fn main() -> Result<()> {
         tracing::info!(mode = %cli.mode, "TEMM1E starting");
     }
 
+    // Initialize file safety guards (captures running binary path for self-protection)
+    temm1e_tools::file_safety::init();
+
     match cli.command {
         Commands::Stop => {
             match read_pid_file() {


### PR DESCRIPTION
## Summary

The Sweep 1 P0 fix (SWEEP-701/702) over-corrected by adding workspace containment to the file tool. Tem couldn't help with cross-project work, sysadmin tasks, or anything outside the directory it was started from. This release reverses that and codifies the AGI principle.

**The principle:** Tem has full computer access on the user's behalf. Blocked only from things that would brick the OS or the Tem instance.

## What changed

- New `crates/temm1e-tools/src/file_safety.rs` — hardcoded block list of catastrophic system paths plus Tem self-binary protection
- `file::resolve_path()` drops workspace containment, keeps path canonicalization, runs `file_safety::is_catastrophic_write()` on writes only
- `executor::validate_arguments()` no longer enforces workspace on path arguments (shell command denylist still active)
- `executor::validate_sandbox()` no longer enforces workspace on declared `file_access` paths
- `prompt_optimizer` system prompt rewritten to advertise full filesystem access
- `file_safety::init()` captures running binary path at startup via `OnceLock`

## What's blocked (the entire list)

**System catastrophic (would brick the OS):**
- `/etc/shadow`, `/etc/sudoers`, `/etc/sudoers.d/*`, `/etc/passwd`, `/etc/group`, `/etc/gshadow`
- `/etc/fstab`, `/etc/crypttab`
- `/boot/*`, `/efi/*`, macOS `/System/Library/CoreServices/boot.efi`, `/System/Library/Kernels/`
- `/dev/sd*`, `/dev/nvme*`, `/dev/disk*`, `/dev/hd*`, `/dev/rdisk*`, `/dev/mmcblk*`
- `/sys/firmware/*`, `/sys/power/*`, `/proc/sysrq-trigger`
- Windows: SAM/SECURITY/SYSTEM/SOFTWARE registry hives, `C:\Boot\*`, `\\.\PhysicalDrive*`, kernel files

**Tem self-instance (would crash the running agent):**
- The currently-running `temm1e` binary (canonical path)
- The `temm1e-watchdog` binary (immutable kernel per Cambium architecture)

**That's it.** No workspace containment. No credential block list. No `~/.temm1e/*` block.

## What's unblocked vs v5.1.0

| Operation | v5.1.0 | v5.1.1 |
|-----------|--------|--------|
| Read `/tmp/anything` | BLOCKED | ALLOWED |
| Write `~/.zshrc` | BLOCKED | ALLOWED |
| Cross-project read/write | BLOCKED | ALLOWED |
| Read `/var/log/*` | BLOCKED | ALLOWED |
| Read `~/.ssh/id_rsa` | BLOCKED | ALLOWED |
| Edit `/etc/hosts` | BLOCKED | ALLOWED |
| Manage `~/.temm1e/*` | BLOCKED | ALLOWED |
| Write `/etc/shadow` | BLOCKED | BLOCKED (catastrophic) |
| Write `/dev/sda` | BLOCKED | BLOCKED (catastrophic) |
| Write running binary | BLOCKED | BLOCKED (self-corruption) |

## Architectural anchor

`docs/AGI_FULL_COMPUTER_USE.md` documents the principle, threat model, defense-in-depth layers, and what future sweeps should never propose. This is a foundational design rule going forward.

## Test plan

- [x] `cargo check --workspace` PASS
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` PASS
- [x] `cargo fmt --all -- --check` PASS
- [x] `cargo test --workspace` PASS — **2414 tests, 0 failures**
- [x] Live CLI test on gemini-2.5-flash:
  - Read `/tmp/temm1e_env.sh` outside workspace — PASS (4 lines)
  - Write `/etc/shadow` (catastrophic) — BLOCKED with reason
  - Write `/tmp/sweep_v511_test.txt` outside workspace — PASS, file created
  - Read it back — PASS, content confirmed

## Harmonization

Verified via deep research that all backend systems (Cambium deploy, Vigil inbox, Vault, Memory, MCP, OAuth, Anima, Distill, Hive) bypass the file tool and use `tokio::fs::` directly. The block list only protects the LLM-controlled file tool path. Cambium's binary swap continues to work because `deploy.rs` uses `tokio::fs::rename()` directly, not the file tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)